### PR TITLE
Fix issue #13 (adds constraint to version of network-conduit)

### DIFF
--- a/dns.cabal
+++ b/dns.cabal
@@ -1,5 +1,5 @@
 Name:                   dns
-Version:                1.2.0
+Version:                1.2.1
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3


### PR DESCRIPTION
This small patch adds a constraint to make sure that the version of network-conduit that is installed includes the modules that this package needs.

Note: it is a temporary fix, since network-conduit is itself deprecated and it should probably be substituted for something else. But existing packages (including the fantastic git-annex) depend on dns, so it's better than nothing.
