### PR TITLE
Added missing preprocessor directive for win32 builds

### DIFF
--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -28,7 +28,9 @@ import Network.DNS.Encode
 import Network.DNS.Internal
 import Network.Socket (HostName, Socket, SocketType(Datagram), sClose, socket, connect)
 import Network.Socket (AddrInfoFlag(..), AddrInfo(..), defaultHints, getAddrInfo)
+#ifndef mingw32_HOST_OS
 import Network.Socket.ByteString.Lazy (sendAll)
+#endif
 import Prelude hiding (lookup)
 import System.Random (getStdRandom, randomR)
 import System.Timeout (timeout)


### PR DESCRIPTION
Hi!

I've noticed that win32 builds of dns-1.2.1 are failing with error message "Network\DNS\Resolver.hs:32:40: Module `Network.Socket.ByteString.Lazy' does not export`sendAll'". Obviously it's just missed ifdef around the import.
