### PR TITLE
Add support for accessing DNS servers running on non-standard ports.

### DIFF
--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -280,7 +280,7 @@ lookupNS = lookupNSImpl DNS.lookup
 --   >>> import Data.List (sort)
 --   >>> let hostname = Data.ByteString.Char8.pack "example.com"
 --   >>>
---   >>> let ri = RCHostName "192.5.6.30" -- a.gtld-servers.net
+--   >>> let ri = RCHostName "192.5.6.30" Nothing -- a.gtld-servers.net
 --   >>> let rc = defaultResolvConf { resolvInfo = ri }
 --   >>> rs <- makeResolvSeed rc
 --   >>> ns <- withResolver rs $ \resolver -> lookupNSAuth resolver hostname


### PR DESCRIPTION
I want to be able to connect to [Consul's DNS service](http://www.consul.io/docs/agent/dns.html), which serves  records on port 8600. This PR allows using a custom port with an RCHostName.
