### PR TITLE
Use Safe.toEnumMay to handle unsupported opcodes gracefully

### DIFF
--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -143,9 +143,21 @@ data DNSFlags = DNSFlags {
 
 data QorR = QR_Query | QR_Response deriving (Eq, Show)
 
-data OPCODE = OP_STD | OP_INV | OP_SSR deriving (Eq, Show, Enum)
+data OPCODE
+  = OP_STD
+  | OP_INV
+  | OP_SSR
+  deriving (Eq, Show, Enum, Bounded)
 
-data RCODE = NoErr | FormatErr | ServFail | NameErr | NotImpl | Refused | BadOpt deriving (Eq, Show, Enum)
+data RCODE
+  = NoErr
+  | FormatErr
+  | ServFail
+  | NameErr
+  | NotImpl
+  | Refused
+  | BadOpt
+  deriving (Eq, Show, Enum, Bounded)
 
 ----------------------------------------------------------------
 

--- a/dns.cabal
+++ b/dns.cabal
@@ -39,6 +39,7 @@ Library
                       , network >= 2.3
                       , random
                       , resourcet
+                      , safe == 0.3.*
   else
     Build-Depends:      base >= 4 && < 5
                       , attoparsec
@@ -54,6 +55,7 @@ Library
                       , network-bytestring
                       , random
                       , resourcet
+                      , safe == 0.3.*
 
 Test-Suite network
   Type:                 exitcode-stdio-1.0
@@ -90,6 +92,7 @@ Test-Suite spec
                       , network >= 2.3
                       , random
                       , resourcet
+                      , safe == 0.3.*
                       , word8
 
 Test-Suite doctest


### PR DESCRIPTION
`toEnum` will fail with an error call if the value is not in bounds. For some DNS messages, this causes the parser to fail.