### PR TITLE
DNS-SEC support

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -98,6 +98,7 @@ decodeFlags = do
                         (getRecDesired flgs)
                         (getRecAvailable flgs)
                         rcode_
+			(getAuthenData flgs)
     getQorR w = if testBit w 15 then QR_Response else QR_Query
     getOpcode w = Safe.toEnumMay (fromIntegral (shiftR w 11 .&. 0x0f))
     getAuthAnswer w = testBit w 10
@@ -105,6 +106,7 @@ decodeFlags = do
     getRecDesired w = testBit w 8
     getRecAvailable w = testBit w 7
     getRcode w = Safe.toEnumMay (fromIntegral (w .&. 0x0f))
+    getAuthenData w = testBit w 5
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -231,6 +231,16 @@ decodeRData OPT ol = RD_OPT <$> decode' ol
             optLen <- getInt16
             dat <- decodeOData optCode optLen
             (dat:) <$> decode' (l - optLen - 4)
+--
+decodeRData TLSA len = RD_TLSA <$> decodeUsage
+                               <*> decodeSelector
+                               <*> decodeMType
+                               <*> decodeADF
+  where
+    decodeUsage    = getInt8
+    decodeSelector = getInt8
+    decodeMType    = getInt8
+    decodeADF      = getNByteString (len - 3)
 decodeRData _  len = RD_OTH <$> getNByteString len
 
 decodeOData :: OPTTYPE -> Int -> SGet OData

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -83,6 +83,7 @@ encodeFlags DNSFlags{..} = put16 word
     st :: State Word16 ()
     st = sequence_
               [ set (word16 rcode)
+              , when authenData          $ set (bit 5)
               , when recAvailable        $ set (bit 7)
               , when recDesired          $ set (bit 8)
               , when trunCation          $ set (bit 9)

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -167,6 +167,12 @@ encodeRDATA rd = case rd of
         , putInt16 port
         , encodeDomain dom
         ]
+    (RD_TLSA u s m d) -> mconcat
+        [ putInt8 u
+        , putInt8 s
+        , putInt8 m
+        , putByteString d
+        ]
 
 encodeOData :: OData -> SPut
 encodeOData (OD_ClientSubnet srcNet scpNet ip) = let dropZeroes = dropWhileEnd (==0)

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -3,6 +3,7 @@
 module Network.DNS.Encode (
     encode
   , composeQuery
+  , composeQueryAD
   ) where
 
 import qualified Blaze.ByteString.Builder as BB
@@ -36,6 +37,21 @@ composeQuery idt qs = encode qry
          }
       , question = qs
       }
+
+composeQueryAD :: Int -> [Question] -> ByteString
+composeQueryAD idt qs = encode qry
+  where
+      hdr = header defaultQuery
+      flg = flags hdr
+      qry = defaultQuery {
+          header = hdr {
+              identifier = idt,
+              flags = flg {
+                  authenData = True
+              }
+           }
+        , question = qs
+        }
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -137,6 +137,7 @@ data DNSFlags = DNSFlags {
   , recDesired   :: Bool
   , recAvailable :: Bool
   , rcode        :: RCODE
+  , authenData   :: Bool
   } deriving (Eq, Show)
 
 ----------------------------------------------------------------
@@ -236,6 +237,7 @@ defaultQuery = DNSMessage {
          , recDesired   = True
          , recAvailable = False
          , rcode        = NoErr
+         , authenData   = False
          }
      }
   , question   = []
@@ -254,6 +256,7 @@ defaultResponse =
               qOrR = QR_Response
             , authAnswer = True
             , recAvailable = True
+            , authenData = False
             }
         }
       }

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -5,6 +5,8 @@ module Network.DNS.Internal where
 import Control.Exception (Exception)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Builder as L
+import qualified Data.ByteString.Lazy as L
 import Data.IP (IP, IPv4, IPv6)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
@@ -28,6 +30,7 @@ data TYPE = A
           | SRV
           | DNAME
           | OPT
+          | TLSA
           | UNKNOWN Int deriving (Eq, Show, Read)
 
 rrDB :: [(TYPE, Int)]
@@ -43,6 +46,7 @@ rrDB = [
   , (SRV,   33)
   , (DNAME, 39) -- RFC 2672
   , (OPT,   41) -- RFC 6891
+  , (TLSA,  52) -- RFC 6898
   ]
 
 data OPTTYPE = ClientSubnet
@@ -202,6 +206,7 @@ data RData = RD_NS Domain
            | RD_SRV Int Int Int Domain
            | RD_OPT [OData]
            | RD_OTH ByteString
+           | RD_TLSA Int Int Int ByteString
     deriving (Eq)
 
 instance Show RData where
@@ -217,6 +222,7 @@ instance Show RData where
   show (RD_SRV pri wei prt dom) = show pri ++ " " ++ show wei ++ " " ++ show prt ++ BS.unpack dom
   show (RD_OPT od) = show od
   show (RD_OTH is) = show is
+  show (RD_TLSA use sel mtype dgst) = show use ++ " " ++ show sel ++ " " ++ show mtype ++ " " ++ (BS.unpack $ L.toStrict . L.toLazyByteString . L.byteStringHex $ dgst)
 
 
 data OData = OD_ClientSubnet Int Int IP

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -14,6 +14,7 @@ module Network.DNS.Resolver (
   , lookupAuth
   -- ** Raw looking up function
   , lookupRaw
+  , lookupRawAD
   , fromDNSMessage
   , fromDNSFormat
   ) where
@@ -307,19 +308,25 @@ lookupAuth = lookupSection authority
 --  @
 --
 lookupRaw :: Resolver -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
-lookupRaw = lookupRawInternal receive
+lookupRaw = lookupRawInternal receive False
+
+lookupRawAD :: Resolver -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
+lookupRawAD = lookupRawInternal receive True
+
+
 
 lookupRawInternal ::
     (Socket -> IO DNSMessage)
+    -> Bool
     -> Resolver
     -> Domain
     -> TYPE
     -> IO (Either DNSError DNSMessage)
-lookupRawInternal _ _   dom _
+lookupRawInternal _ _ _   dom _
   | isIllegal dom     = return $ Left IllegalDomain
-lookupRawInternal rcv rlv dom typ = do
+lookupRawInternal rcv ad rlv dom typ = do
     seqno <- genId rlv
-    let query = composeQuery seqno [q]
+    let query = (if ad then composeQueryAD else composeQuery) seqno [q]
         checkSeqno = check seqno
     loop query checkSeqno 0 False
   where

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -291,7 +291,9 @@ lookupAuth = lookupSection authority
 --                                      trunCation = False,
 --                                      recDesired = True,
 --                                      recAvailable = True,
---                                      rcode = NoErr },
+--                                      rcode = NoErr,
+--                                      authenData = False
+--                                    },
 --                        },
 --             question = [Question { qname = \"www.example.com.\",
 --                                    qtype = A}],

--- a/dns.cabal
+++ b/dns.cabal
@@ -1,5 +1,5 @@
 Name:                   dns
-Version:                2.0.4
+Version:                2.0.4.1
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3

--- a/dns.cabal
+++ b/dns.cabal
@@ -31,6 +31,7 @@ Library
                       , binary
                       , blaze-builder
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers
@@ -46,6 +47,7 @@ Library
                       , binary
                       , blaze-builder
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers
@@ -67,6 +69,7 @@ Test-Suite network
   Build-Depends:        dns
                       , base
                       , bytestring
+                      , bytestring-builder
                       , hspec
 
 Test-Suite spec
@@ -82,6 +85,7 @@ Test-Suite spec
                       , binary
                       , blaze-builder
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers

--- a/test/EncodeSpec.hs
+++ b/test/EncodeSpec.hs
@@ -67,6 +67,7 @@ testResponseA = DNSMessage {
          , recDesired = True
          , recAvailable = True
          , rcode = NoErr
+         , authenData = False
          }
        }
   , question = [Question {
@@ -175,6 +176,7 @@ testResponseTXT = DNSMessage {
          , recDesired = True
          , recAvailable = True
          , rcode = NoErr
+         , authenData = False
          }
        }
   , question = [Question {


### PR DESCRIPTION
Added support for TLSA record lookup and AD (authenticated data) bit to query headers

Type signatures of some internal functions (see commit notes) were changed, but this shouldn't break anything as the API is largely unmodified.