### PR TITLE
test2/doctests.hs: ignore 'network-data' package

### DIFF
--- a/test2/doctests.hs
+++ b/test2/doctests.hs
@@ -5,5 +5,13 @@ import Test.DocTest
 main :: IO ()
 main = doctest [
     "-XOverloadedStrings"
+  {-
+    Both 'iproute' and 'network-data' provide
+    ‘Data.IP’ package:
+      Ambiguous interface for ‘Data.IP’:
+        it was found in multiple packages: network-data-0.5.3 iproute-1.7.0
+    We ignore network-data to make tests pass.
+  -}
+  , "-ignore-package=network-data"
   , "Network/DNS.hs"
   ]


### PR DESCRIPTION
Before the change tests fail on system
with many packages including iproute
and network-data installed globally:

  Test suite logged to: dist/test/dns-2.0.5-spec.log
  Test suite doctest: RUNNING...

  Network/DNS/Decode.hs:20:1: error:
    Ambiguous interface for ‘Data.IP’:
      it was found in multiple packages: network-data-0.5.3 iproute-1.7.0

Signed-off-by: Sergei Trofimovich <siarheit@google.com>