### PR TITLE
Make it possible to sort more DNS data types

### DIFF
--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -162,7 +162,7 @@ data RCODE
   | NotImpl
   | Refused
   | BadOpt
-  deriving (Eq, Show, Enum, Bounded)
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 ----------------------------------------------------------------
 
@@ -207,7 +207,7 @@ data RData = RD_NS Domain
            | RD_OPT [OData]
            | RD_OTH ByteString
            | RD_TLSA Int Int Int ByteString
-    deriving (Eq)
+    deriving (Eq, Ord)
 
 instance Show RData where
   show (RD_NS dom) = BS.unpack dom
@@ -227,7 +227,7 @@ instance Show RData where
 
 data OData = OD_ClientSubnet Int Int IP
            | OD_Unknown Int ByteString
-    deriving (Eq,Show)
+    deriving (Eq,Show,Ord)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
It is sometimes useful to sort RRs in a predictable order.  It would also be useful to be able to sort RData objects in their canonical wire form, because signatures on DNSSEC records are over such sorted representations of RRsets, but that is for another time...