### PR TITLE
Better handling of encoding and decoding the "root" domain "."

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -269,7 +269,7 @@ decodeDomain = do
     let n = getValue c
     -- Syntax hack to avoid using MultiWayIf
     case () of
-        _ | c == 0 -> return ""
+        _ | c == 0 -> return "." -- Perhaps the root domain?
         _ | isPointer c -> do
             d <- getInt8
             let offset = n * 256 + d
@@ -285,7 +285,10 @@ decodeDomain = do
         _ | otherwise -> do
             hs <- getNByteString n
             ds <- decodeDomain
-            let dom = hs `BS.append` "." `BS.append` ds
+            let dom =
+                    case ds of -- avoid trailing ".."
+                        "." -> hs `BS.append` "."
+                        _   -> hs `BS.append` "." `BS.append` ds
             push pos dom
             return dom
   where

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -201,9 +201,12 @@ putByteStringWithLength bs = putInt8 (fromIntegral $ BS.length bs) -- put the le
 
 ----------------------------------------------------------------
 
+rootDomain :: Domain
+rootDomain = BS.pack "."
+
 encodeDomain :: Domain -> SPut
 encodeDomain dom
-    | BS.null dom = put8 0
+    | (BS.null dom || dom == rootDomain) = put8 0
     | otherwise = do
         mpos <- wsPop dom
         cur <- gets wsPosition


### PR DESCRIPTION
Without this, records like:

    arlott.org.uk. IN MX 0 .

fail to display correctly (the final "." is missing), and conversely
lookups of the various (e.g. NS) records of the root domain "." fail.