### PR TITLE
Implemented TCP fallback after a truncated UDP response.

### DIFF
--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -2,6 +2,7 @@
 
 module Network.DNS.Encode (
     encode
+  , encodeVC
   , composeQuery
   , composeQueryAD
   ) where
@@ -60,6 +61,11 @@ composeQueryAD idt qs = encode qry
 
 encode :: DNSMessage -> ByteString
 encode msg = runSPut (encodeDNSMessage msg)
+
+encodeVC :: ByteString -> ByteString
+encodeVC query =
+    let len = BB.toLazyByteString $ BB.int16BE $ fromIntegral $ BL.length query
+    in len <> query
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -115,9 +115,8 @@ data DNSError =
     -- | The name server was unable to process this query due to a
     --   problem with the name server.
   | ServerFailure
-    -- | Meaningful only for responses from an authoritative name
-    -- server, this code signifies that the
-    -- domain name referenced in the query does not exist.
+    -- | This code signifies that the domain name referenced in the
+    --   query does not exist.
   | NameError
     -- | The name server does not support the requested kind of query.
   | NotImplemented

--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -373,8 +373,9 @@ lookupRDNS rlv ip = lookupPTR rlv dom
 
 ----------------------------------------------------------------
 
--- | Look up all \'SRV\' records for the given hostname. A SRV record
---   comprises four fields,
+-- | Look up all \'SRV\' records for the given hostname. SRV records
+--   consist (see <https://tools.ietf.org/html/rfc2782>) of the
+--   following four fields:
 --
 --     * Priority (lower is more-preferred)
 --
@@ -391,12 +392,18 @@ lookupRDNS rlv ip = lookupPTR rlv dom
 --
 --   Examples:
 --
---   >>> let hostname = Data.ByteString.Char8.pack "_sip._tcp.cisco.com"
+--   >>> let q = Data.ByteString.Char8.pack "_xmpp-server._tcp.jabber.ietf.org"
 --   >>>
 --   >>> rs <- makeResolvSeed defaultResolvConf
---   >>> withResolver rs $ \resolver -> lookupSRV resolver hostname
---   Right [(1,0,5060,"vcsgw.cisco.com.")]
---
+--   >>> withResolver rs $ \resolver -> lookupSRV resolver q
+--   Right [(5,0,5269,"jabber.ietf.org.")]
+
+-- Though the "jabber.ietf.orgs" SRV record may prove reasonably stable, as
+-- with anything else published in DNS it is subject to change.  Also, this
+-- example only works when connected to the Internet.  Perhaps the above
+-- example should be displayed in a format that is not recognized as a test
+-- by "doctest".
+
 lookupSRV :: Resolver -> Domain -> IO (Either DNSError [(Int,Int,Int,Domain)])
 lookupSRV rlv dom = do
   erds <- DNS.lookup rlv dom SRV


### PR DESCRIPTION
For example, the TLSA records for ``_25._tcp.mail.socialmiwu.de`` don't fit in a 512-byte UDP response (dig reports 596 bytes, and fails over to TCP, when EDNS0 is disabled).  The updated code is likewise able to retrieve the answer over TCP.

Please check that the implementation style matches how you want to code to be structured.  This PR strays into new territory for me, and it is less obvious what the preferred method is for reading the length bytes from a TCP socket, followed by that many bytes of response.

I should also note, that it is not clear how ParseErrors should be reported.  Should these be turned into (new?) DNS errors, or remain exceptions for the caller to `catch` (unlike DNS errors that are returned via ``Either``).  Mind you, this question is certainly not new with the addition of TCP fallback.  Malformed responses over UDP also raise the same issue.