### PR TITLE
TCP retry code cleanup

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -256,9 +256,9 @@ decodeRData TLSA len = RD_TLSA <$> decodeUsage
                                <*> decodeMType
                                <*> decodeADF
   where
-    decodeUsage    = getInt8
-    decodeSelector = getInt8
-    decodeMType    = getInt8
+    decodeUsage    = get8
+    decodeSelector = get8
+    decodeMType    = get8
     decodeADF      = getNByteString (len - 3)
 decodeRData _  len = RD_OTH <$> getNByteString len
 

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -176,9 +176,9 @@ encodeRDATA rd = case rd of
         , encodeDomain dom
         ]
     (RD_TLSA u s m d) -> mconcat
-        [ putInt8 u
-        , putInt8 s
-        , putInt8 m
+        [ put8 u
+        , put8 s
+        , put8 m
         , putByteString d
         ]
 

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -16,6 +16,9 @@ import Data.Typeable (Typeable)
 -- | Type for domain.
 type Domain = ByteString
 
+-- | Return type of composeQuery from Encode, needed in Resolver
+type Query = L.ByteString
+
 ----------------------------------------------------------------
 
 -- | Types for resource records.

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString.Lazy as L
 import Data.IP (IP, IPv4, IPv6)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
+import Data.Word (Word8)
 
 ----------------------------------------------------------------
 
@@ -228,7 +229,7 @@ data RData = RD_NS Domain
            | RD_SRV Int Int Int Domain
            | RD_OPT [OData]
            | RD_OTH ByteString
-           | RD_TLSA Int Int Int ByteString
+           | RD_TLSA Word8 Word8 Word8 ByteString
     deriving (Eq, Ord)
 
 instance Show RData where


### PR DESCRIPTION
Though the pattern guard was legitimate, it was unnecessary, so I simplified it anyway.

While I was there, I took the opportunity to split off local helper functions as top-level definitions, and add comments.  This work adds no functionality and fixes no bugs, so does not merit a new release, but may be useful to stage for the next convenient opportunity.

Feedback welcome, this is supposed to make the code more clear.
Some of the comments ask questions about error handling, feedback on that especially welcome.