### PR TITLE
Change DNSHeader identifier field to Word16

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -140,7 +140,7 @@ decodeHeader = do
              ,arCount
              )
   where
-    decodeIdentifier = getInt16
+    decodeIdentifier = get16
     decodeQdCount = getInt16
     decodeAnCount = getInt16
     decodeNsCount = getInt16

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -29,7 +29,7 @@ import Data.Monoid (mconcat)
 
 -- | Composing query. First argument is a number to identify response.
 
-composeQuery :: Int -> [Question] -> ByteString
+composeQuery :: Word16 -> [Question] -> ByteString
 composeQuery idt qs = encode qry
   where
     hdr = header defaultQuery
@@ -40,7 +40,7 @@ composeQuery idt qs = encode qry
       , question = qs
       }
 
-composeQueryAD :: Int -> [Question] -> ByteString
+composeQueryAD :: Word16 -> [Question] -> ByteString
 composeQueryAD idt qs = encode qry
   where
       hdr = header defaultQuery
@@ -92,7 +92,7 @@ encodeHeader :: DNSHeader -> SPut
 encodeHeader hdr = encodeIdentifier (identifier hdr)
                 <> encodeFlags (flags hdr)
   where
-    encodeIdentifier = putInt16
+    encodeIdentifier = put16
 
 encodeFlags :: DNSFlags -> SPut
 encodeFlags DNSFlags{..} = put16 word

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -151,7 +151,7 @@ type DNSFormat = DNSMessage
 
 -- | Raw data format for the header of DNS Query and Response.
 data DNSHeader = DNSHeader {
-    identifier :: Int
+    identifier :: Word16
   , flags      :: DNSFlags
   } deriving (Eq, Show)
 
@@ -292,7 +292,7 @@ defaultResponse =
         }
       }
 
-responseA :: Int -> Question -> [IPv4] -> DNSMessage
+responseA :: Word16 -> Question -> [IPv4] -> DNSMessage
 responseA ident q ips =
   let hd = header defaultResponse
       dom = qname q
@@ -303,7 +303,7 @@ responseA ident q ips =
         , answer = an
       }
 
-responseAAAA :: Int -> Question -> [IPv6] -> DNSMessage
+responseAAAA :: Word16 -> Question -> [IPv6] -> DNSMessage
 responseAAAA ident q ips =
   let hd = header defaultResponse
       dom = qname q

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -34,9 +34,9 @@ import Network.Socket (Family(AF_INET, AF_INET6), PortNumber(..))
 import Network.Socket (close, socket, connect, getPeerName, getAddrInfo)
 import Network.Socket (defaultHints, defaultProtocol)
 import Prelude hiding (lookup)
-import System.Random (getStdRandom, randomR)
+import System.Random (getStdRandom, random)
 import System.Timeout (timeout)
-
+import Data.Word (Word16)
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative ((<$>), (<*>), pure)
 #endif
@@ -115,7 +115,7 @@ data ResolvSeed = ResolvSeed {
 -- | Abstract data type of DNS Resolver
 --   When implementing a DNS cache, this MUST NOT be re-used.
 data Resolver = Resolver {
-    genId   :: IO Int
+    genId   :: IO Word16
   , dnsSock :: Socket
   , dnsTimeout :: Int
   , dnsRetry :: Int
@@ -206,8 +206,8 @@ makeResolver seed sock = Resolver {
   , dnsBufsize = rsBufsize seed
   }
 
-getRandom :: IO Int
-getRandom = getStdRandom (randomR (0,65535))
+getRandom :: IO Word16
+getRandom = getStdRandom random
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
The `identifier` field was `Int`, but the specs say its `Word16` so
its better to use `Word16`.

Closes: https://github.com/kazu-yamamoto/dns/issues/27