### PR TITLE
Fix the StateBinary.get32 parser

### DIFF
--- a/Network/DNS/StateBinary.hs
+++ b/Network/DNS/StateBinary.hs
@@ -125,7 +125,7 @@ get16 = ST.lift getWord16be <* addPosition 2
     getWord16be = do
         a <- word8'
         b <- word8'
-        return $ a * 256 + b
+        return $ a * 0x100 + b
 
 get32 :: SGet Word32
 get32 = ST.lift getWord32be <* addPosition 4
@@ -136,7 +136,7 @@ get32 = ST.lift getWord32be <* addPosition 4
         b <- word8'
         c <- word8'
         d <- word8'
-        return $ a * 1677721 + b * 65536 + c * 256 + d
+        return $ a * 0x1000000 + b * 0x10000 + c * 0x100 + d
 
 getInt8 :: SGet Int
 getInt8 = fromIntegral <$> get8

--- a/test/RoundTripSpec.hs
+++ b/test/RoundTripSpec.hs
@@ -88,7 +88,7 @@ genResourceRecord = frequency
     genRR = do
       dom <- genDomain
       t <- elements [A , AAAA, NS, TXT, MX, CNAME, SOA, PTR, SRV, DNAME, DS]
-      ResourceRecord dom t <$> genTTL <*> mkRData dom t
+      ResourceRecord dom t <$> genWord32 <*> mkRData dom t
     genRDataOpt = do
       odata <- listOf genOData
       pure $ ResourceRecord "" OPT (fromIntegral $ length odata) (RD_OPT odata)
@@ -96,9 +96,6 @@ genResourceRecord = frequency
       dom <- genDomain
       t <- genTYPE
       OptRecord <$> genWord16 <*> genBool <*> genWord8 <*> mkRData dom t
-
-genTTL :: Gen Word32
-genTTL = choose (0, 0xffffff)
 
 mkRData :: Domain -> TYPE -> Gen RData
 mkRData dom typ =
@@ -109,7 +106,7 @@ mkRData dom typ =
         TXT -> RD_TXT <$> genByteString
         MX -> RD_MX <$> genWord16 <*> genDomain
         CNAME -> pure $ RD_CNAME dom
-        SOA -> RD_SOA dom <$> genDomain <*> genTTL <*> genTTL <*> genTTL <*> genTTL <*> genTTL
+        SOA -> RD_SOA dom <$> genDomain <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32
         PTR -> RD_PTR <$> genDomain
         SRV -> RD_SRV <$> genWord16 <*> genWord16 <*> genWord16 <*> genDomain
         DNAME -> RD_DNAME <$> genDomain


### PR DESCRIPTION
Found when round-tripping packets captured with Wireshark.
