### PR TITLE
Remove bytestring-builder dependency.

### DIFF
--- a/dns.cabal
+++ b/dns.cabal
@@ -30,7 +30,6 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
-                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers
@@ -45,7 +44,6 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
-                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers


### PR DESCRIPTION
It was removed in b00335f8b0a6e1c287f87450190fda266968ae58.

Or at the very least, according to its docs, it's merged into GHC 7.8, and since the Travis build here dropped 7.6, I'd guess it shouldn't be necessary.