### PR TITLE
Fix Windows build

### DIFF
--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -441,11 +441,12 @@ tcpLookup query peer tm (Just vc) = do
         Just res -> return $ Right res
 
 #if mingw32_HOST_OS == 1
-    -- Windows does not support sendAll in Network.ByteString.
-    -- This implements sendAll with Haskell Strings.
-    sendAll sock bs = do
-	sent <- send sock (LB.unpack bs)
-	when (sent < fromIntegral (LB.length bs)) $ sendAll sock (LB.drop (fromIntegral sent) bs)
+-- Windows does not support sendAll in Network.ByteString.
+-- This implements sendAll with Haskell Strings.
+sendAll :: Socket -> BS.ByteString -> IO ()
+sendAll sock bs = do
+  sent <- send sock (BS.unpack bs)
+  when (sent < fromIntegral (BS.length bs)) $ sendAll sock (BS.drop (fromIntegral sent) bs)
 #endif
 
 isIllegal :: Domain -> Bool


### PR DESCRIPTION
Trying to build `dns` on GHC 8.2.1 on Windows yields this build error.

```
Building library for dns-2.0.10..
[1 of 9] Compiling Network.DNS.Internal ( Network\DNS\Internal.hs, dist\build\Network\DNS\Internal.o )
[2 of 9] Compiling Network.DNS.Types ( Network\DNS\Types.hs, dist\build\Network\DNS\Types.o )
[3 of 9] Compiling Network.DNS.StateBinary ( Network\DNS\StateBinary.hs, dist\build\Network\DNS\StateBinary.o )
[4 of 9] Compiling Network.DNS.Encode ( Network\DNS\Encode.hs, dist\build\Network\DNS\Encode.o )
[5 of 9] Compiling Network.DNS.Decode ( Network\DNS\Decode.hs, dist\build\Network\DNS\Decode.o )
[6 of 9] Compiling Network.DNS.Resolver ( Network\DNS\Resolver.hs, dist\build\Network\DNS\Resolver.o )

Network\DNS\Resolver.hs:446:21: error:
    parse error on input `='
    Perhaps you need a 'let' in a 'do' block?
    e.g. 'let x = 5' instead of 'x = 5'
    |
446 |     sendAll sock bs = do
    |                     ^
```

I've attempted to fix the error in this PR.