### PR TITLE
Restore previous Show instances for RData and implement RD_DNSKEY

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -271,6 +271,16 @@ getRData DS len = RD_DS <$> decodeTag
     decodeDtyp = get8
     decodeDval = getNByteString (len - 4)
 --
+getRData DNSKEY len = RD_DNSKEY <$> decodeKeyFlags
+                                <*> decodeKeyProto
+                                <*> decodeKeyAlg
+                                <*> decodeKeyBytes
+  where
+    decodeKeyFlags  = get16
+    decodeKeyProto  = get8
+    decodeKeyAlg    = get8
+    decodeKeyBytes  = getNByteString (len - 4)
+--
 getRData _  len = RD_OTH <$> getNByteString len
 
 getOData :: OPTTYPE -> Int -> SGet OData

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -206,6 +206,12 @@ putRData rd = case rd of
         , put8 dt
         , putByteString dv
         ]
+    (RD_DNSKEY f p a k) -> mconcat
+        [ put16 f
+        , put8 p
+        , put8 a
+        , putByteString k
+        ]
 
 putOData :: OData -> SPut
 putOData (OD_ClientSubnet srcNet scpNet ip) =

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -4,6 +4,7 @@ module Network.DNS.Internal where
 
 import Control.Exception (Exception)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base64 as B64 (encode)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Builder as L
 import qualified Data.ByteString.Lazy as L
@@ -227,6 +228,7 @@ data RData = RD_NS Domain
            | RD_OTH ByteString
            | RD_TLSA Word8 Word8 Word8 ByteString
            | RD_DS Word16 Word8 Word8 ByteString
+           | RD_DNSKEY Word16 Word8 Word8 ByteString
     deriving (Eq, Ord)
 
 data OData = OD_ClientSubnet Word8 Word8 IP
@@ -248,9 +250,13 @@ instance Show RData where
   show (RD_OTH is) = show is
   show (RD_TLSA use sel mtype dgst) = show use ++ " " ++ show sel ++ " " ++ show mtype ++ " " ++ hexencode dgst
   show (RD_DS t a dt dv) = show t ++ " " ++ show a ++ " " ++ show dt ++ " " ++ hexencode dv
+  show (RD_DNSKEY f p a k) = show f ++ " " ++ show p ++ " " ++ show a ++ " " ++ b64encode k
 
 hexencode :: ByteString -> String
 hexencode = BS.unpack . L.toStrict . L.toLazyByteString . L.byteStringHex
+
+b64encode :: ByteString -> String
+b64encode = BS.unpack . B64.encode
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -4,6 +4,9 @@ module Network.DNS.Internal where
 
 import Control.Exception (Exception)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Builder as L
+import qualified Data.ByteString.Lazy as L
 import Data.IP (IP, IPv4, IPv6)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
@@ -224,11 +227,30 @@ data RData = RD_NS Domain
            | RD_OTH ByteString
            | RD_TLSA Word8 Word8 Word8 ByteString
            | RD_DS Word16 Word8 Word8 ByteString
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord)
 
 data OData = OD_ClientSubnet Word8 Word8 IP
            | OD_Unknown Int ByteString
     deriving (Eq,Show,Ord)
+
+instance Show RData where
+  show (RD_NS dom) = BS.unpack dom
+  show (RD_MX prf dom) = show prf ++ " " ++ BS.unpack dom
+  show (RD_CNAME dom) = BS.unpack dom
+  show (RD_DNAME dom) = BS.unpack dom
+  show (RD_A a) = show a
+  show (RD_AAAA aaaa) = show aaaa
+  show (RD_TXT txt) = BS.unpack txt
+  show (RD_SOA mn _ _ _ _ _ mi) = BS.unpack mn ++ " " ++ show mi
+  show (RD_PTR dom) = BS.unpack dom
+  show (RD_SRV pri wei prt dom) = show pri ++ " " ++ show wei ++ " " ++ show prt ++ BS.unpack dom
+  show (RD_OPT od) = show od
+  show (RD_OTH is) = show is
+  show (RD_TLSA use sel mtype dgst) = show use ++ " " ++ show sel ++ " " ++ show mtype ++ " " ++ hexencode dgst
+  show (RD_DS t a dt dv) = show t ++ " " ++ show a ++ " " ++ show dt ++ " " ++ hexencode dv
+
+hexencode :: ByteString -> String
+hexencode = BS.unpack . L.toStrict . L.toLazyByteString . L.byteStringHex
 
 ----------------------------------------------------------------
 

--- a/dns.cabal
+++ b/dns.cabal
@@ -30,6 +30,7 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers
@@ -44,6 +45,7 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers

--- a/dns.cabal
+++ b/dns.cabal
@@ -28,6 +28,7 @@ Library
   if impl(ghc >= 7)
     Build-Depends:      base >= 4 && < 5
                       , attoparsec
+                      , base64-bytestring
                       , binary
                       , bytestring
                       , bytestring-builder
@@ -43,6 +44,7 @@ Library
   else
     Build-Depends:      base >= 4 && < 5
                       , attoparsec
+                      , base64-bytestring
                       , binary
                       , bytestring
                       , bytestring-builder


### PR DESCRIPTION
Until recently, this Show instance used to output most (if not all)
DNS records in the DNS *presentation* format, as defined in various
DNS-related RFCs.  Changing this to use Haskell's default "show" is a
major incompatible change and forces applications that want to show DNS
records to users to re-implement the original show routines