### PR TITLE
More complete SOA implementation and subsume 67 and 69

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -3,6 +3,7 @@
 module Network.DNS.Decode (
     decode
   , decodeDomain
+  , decodeMailbox
   , decodeDNSFlags
   , decodeDNSHeader
   , decodeResourceRecord
@@ -93,6 +94,9 @@ decodeDNSHeader bs = fst <$> runSGet getHeader bs
 
 decodeDomain :: ByteString -> Either String Domain
 decodeDomain bs = fst <$> runSGet getDomain bs
+
+decodeMailbox :: ByteString -> Either String Mailbox
+decodeMailbox bs = fst <$> runSGet getMailbox bs
 
 decodeResourceRecord :: ByteString -> Either String ResourceRecord
 decodeResourceRecord bs = fst <$> runSGet getResourceRecord bs
@@ -225,8 +229,8 @@ getRData A len
 getRData AAAA len
   | len == 16 = (RD_AAAA . toIPv6b) <$> getNBytes len
   | otherwise = fail "IPv6 addresses must be 16 bytes long"
-getRData SOA _ = RD_SOA <$> getDomain
-                           <*> getDomain
+getRData SOA _ = RD_SOA    <$> getDomain
+                           <*> getMailbox
                            <*> decodeSerial
                            <*> decodeRefesh
                            <*> decodeRetry
@@ -307,7 +311,16 @@ getOData (OUNKNOWN i) len = OD_Unknown i <$> getNByteString len
 ----------------------------------------------------------------
 
 getDomain :: SGet Domain
-getDomain = do
+getDomain = getDomain' '.'
+
+getMailbox :: SGet Mailbox
+getMailbox = getDomain' '@'
+
+-- | Get a domain name, using sep1 as the separate between the 1st and 2nd
+-- label.  Subsequent labels (and always the trailing label) are terminated
+-- with a ".".
+getDomain' :: Char -> SGet ByteString
+getDomain' sep1 = do
     pos <- getPosition
     c <- getInt8
     let n = getValue c
@@ -328,11 +341,11 @@ getDomain = do
         _ | isExtLabel c -> return ""
         _ -> do
             hs <- getNByteString n
-            ds <- getDomain
+            ds <- getDomain' '.'
             let dom =
                     case ds of -- avoid trailing ".."
                         "." -> hs `BS.append` "."
-                        _   -> hs `BS.append` "." `BS.append` ds
+                        _   -> hs `BS.append` BS.singleton sep1 `BS.append` ds
             push pos dom
             return dom
   where

--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -279,6 +279,16 @@ getRData DS len = RD_DS <$> decodeTag
     decodeDtyp = get8
     decodeDval = getNByteString (len - 4)
 --
+getRData DNSKEY len = RD_DNSKEY <$> decodeKeyFlags
+                                <*> decodeKeyProto
+                                <*> decodeKeyAlg
+                                <*> decodeKeyBytes
+  where
+    decodeKeyFlags  = get16
+    decodeKeyProto  = get8
+    decodeKeyAlg    = get8
+    decodeKeyBytes  = getNByteString (len - 4)
+--
 getRData _  len = RD_OTH <$> getNByteString len
 
 getOData :: OPTTYPE -> Int -> SGet OData

--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -185,14 +185,22 @@ getResourceRecord = do
         dok <- decodeDNSOK   -- 16
         len <- decodeRLen    -- 16
         dat <- getRData OPT len
-        return $ OptRecord udps dok ver dat
+        return OptRecord { orudpsize = udps
+                         , ordnssecok = dok
+                         , orversion = ver
+                         , ordata = dat
+                         }
 
     getRR dom t = do
         ignoreClass
         ttl <- decodeTTL
         len <- decodeRLen
         dat <- getRData t len
-        return $ ResourceRecord dom t ttl dat
+        return ResourceRecord { rrname = dom
+                              , rrtype = t
+                              , rrttl  = ttl
+                              , rdata  = dat
+                              }
 
     decodeUDPSize = get16
     decodeERCode = get8

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -205,6 +205,12 @@ putRData rd = case rd of
         , put8 dt
         , putByteString dv
         ]
+    (RD_DNSKEY f p a k) -> mconcat
+        [ put16 f
+        , put8 p
+        , put8 a
+        , putByteString k
+        ]
 
 putOData :: OData -> SPut
 putOData (OD_ClientSubnet srcNet scpNet ip) =

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -5,6 +5,7 @@ module Network.DNS.Encode (
   , encodeDNSFlags
   , encodeDNSHeader
   , encodeDomain
+  , encodeMailbox
   , encodeResourceRecord
   , encodeVC
   , composeQuery
@@ -79,6 +80,9 @@ encodeDNSHeader = runSPut . putHeader
 
 encodeDomain :: Domain -> ByteString
 encodeDomain = runSPut . putDomain
+
+encodeMailbox :: Mailbox -> ByteString
+encodeMailbox = runSPut . putMailbox
 
 encodeResourceRecord :: ResourceRecord -> ByteString
 encodeResourceRecord rr = runSPut $ putResourceRecord rr
@@ -178,9 +182,9 @@ putRData rd = case rd of
     RD_TXT txt      -> putByteStringWithLength txt
     RD_OTH bytes    -> putByteString bytes
     RD_OPT opts     -> mconcat $ fmap putOData opts
-    RD_SOA d1 d2 serial refresh retry expire min' -> mconcat
-        [ putDomain d1
-        , putDomain d2
+    RD_SOA mn mr serial refresh retry expire min' -> mconcat
+        [ putDomain mn
+        , putMailbox mr
         , put32 serial
         , put32 refresh
         , put32 retry
@@ -244,7 +248,13 @@ rootDomain :: Domain
 rootDomain = BS.pack "."
 
 putDomain :: Domain -> SPut
-putDomain dom
+putDomain = putDomain' '.'
+
+putMailbox :: Mailbox -> SPut
+putMailbox = putDomain' '@'
+
+putDomain' :: Char -> ByteString -> SPut
+putDomain' sep dom
     | BS.null dom || dom == rootDomain = put8 0
     | otherwise = do
         mpos <- wsPop dom
@@ -253,10 +263,13 @@ putDomain dom
             Just pos -> putPointer pos
             Nothing  -> wsPush dom cur >>
                         mconcat [ putPartialDomain hd
-                                , putDomain tl
+                                , putDomain' '.' tl
                                 ]
   where
-    (hd, tl') = BS.break (=='.') dom
+    (hd, tl') = case sep of
+        '.' -> BS.break (== '.') dom
+        _ | sep `BS.elem` dom -> BS.break (== sep) dom
+          | otherwise -> BS.break (== '.') dom
     tl = if BS.null tl' then tl' else BS.drop 1 tl'
 
 putPointer :: Int -> SPut

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -141,21 +141,21 @@ putQuestion Question{..} = putDomain qname
 putResourceRecord :: ResourceRecord -> SPut
 putResourceRecord rr =
     case rr of
-        ResourceRecord rrname rrtype rrttl rdata ->
+        ResourceRecord{..} ->
             mconcat [ putDomain rrname
                     , put16 (typeToInt rrtype)
                     , put16 1
                     , put32 rrttl
                     , putResourceRData rdata
                     ]
-        OptRecord orudpsize ordnssecok orversion rdata ->
+        OptRecord{..} ->
             mconcat [ putDomain BS.empty
                     , put16 (typeToInt OPT)
                     , put16 orudpsize
                     , put8 0   -- ERCode
                     , put8 orversion
                     , putInt16 $ if ordnssecok then setBit 0 15 else 0
-                    , putResourceRData rdata
+                    , putResourceRData ordata
                     ]
   where
     putResourceRData :: RData -> SPut
@@ -165,7 +165,6 @@ putResourceRecord rr =
         let rdataLength = fromIntegral . LBS.length . BB.toLazyByteString $ rDataBuilder
         let rlenBuilder = BB.int16BE rdataLength
         return $ rlenBuilder <> rDataBuilder
-
 
 putRData :: RData -> SPut
 putRData rd = case rd of

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -5,6 +5,7 @@ module Network.DNS.Internal where
 
 import Control.Exception (Exception)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base64 as B64 (encode)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Builder as L
 import qualified Data.ByteString.Lazy as L
@@ -238,6 +239,7 @@ data RData = RD_NS Domain
            | RD_OTH ByteString
            | RD_TLSA Word8 Word8 Word8 ByteString
            | RD_DS Word16 Word8 Word8 ByteString
+           | RD_DNSKEY Word16 Word8 Word8 ByteString
     deriving (Eq, Ord)
 
 data OData = OD_ClientSubnet Word8 Word8 IP
@@ -259,9 +261,13 @@ instance Show RData where
   show (RD_OTH is) = show is
   show (RD_TLSA use sel mtype dgst) = show use ++ " " ++ show sel ++ " " ++ show mtype ++ " " ++ hexencode dgst
   show (RD_DS t a dt dv) = show t ++ " " ++ show a ++ " " ++ show dt ++ " " ++ hexencode dv
+  show (RD_DNSKEY f p a k) = show f ++ " " ++ show p ++ " " ++ show a ++ " " ++ b64encode k
 
 hexencode :: ByteString -> String
 hexencode = BS.unpack . L.toStrict . L.toLazyByteString . L.byteStringHex
+
+b64encode :: ByteString -> String
+b64encode = BS.unpack . B64.encode
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -19,6 +19,11 @@ import Data.Word (Word8, Word16, Word32)
 -- | Type for domain.
 type Domain = ByteString
 
+-- | Type for a mailbox encoded on the wire as a DNS name, but the first label
+-- is conceptually the user name, and sometimes has internal '.' characters
+-- that are not label separators.
+type Mailbox = ByteString
+
 -- | Return type of composeQuery from Encode, needed in Resolver
 type Query = ByteString
 
@@ -230,7 +235,7 @@ data RData = RD_NS Domain
            | RD_DNAME Domain
            | RD_MX Word16 Domain
            | RD_PTR Domain
-           | RD_SOA Domain Domain Word32 Word32 Word32 Word32 Word32
+           | RD_SOA Domain Mailbox Word32 Word32 Word32 Word32 Word32
            | RD_A IPv4
            | RD_AAAA IPv6
            | RD_TXT ByteString
@@ -254,7 +259,9 @@ instance Show RData where
   show (RD_A a) = show a
   show (RD_AAAA aaaa) = show aaaa
   show (RD_TXT txt) = BS.unpack txt
-  show (RD_SOA mn _ _ _ _ _ mi) = BS.unpack mn ++ " " ++ show mi
+  show (RD_SOA mn mr serial refresh retry expire mi) = BS.unpack mn ++ " " ++ BS.unpack mr ++ " " ++
+                                                       show serial ++ " " ++ show refresh ++ " " ++
+                                                       show retry ++ " " ++ show expire ++ " " ++ show mi
   show (RD_PTR dom) = BS.unpack dom
   show (RD_SRV pri wei prt dom) = show pri ++ " " ++ show wei ++ " " ++ show prt ++ BS.unpack dom
   show (RD_OPT od) = show od

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Network.DNS.Internal where
 
@@ -200,14 +201,24 @@ makeQuestion = Question
 ----------------------------------------------------------------
 
 -- | Raw data format for resource records.
-data ResourceRecord
-    = ResourceRecord Domain TYPE Word32 RData
-    | OptRecord Word16 Bool Word8 RData
-    deriving (Eq,Show)
+
+data ResourceRecord = ResourceRecord {
+                            rrname :: Domain
+                          , rrtype :: TYPE
+                          , rrttl  :: Word32
+                          , rdata  :: RData
+                          }
+                    | OptRecord {
+                            orudpsize   :: Word16
+                          , ordnssecok  :: Bool
+                          , orversion   :: Word8
+                          , ordata      :: RData
+                          }
+                    deriving (Eq,Show)
 
 getRdata :: ResourceRecord -> RData
-getRdata (ResourceRecord _ _ _ rdata) = rdata
-getRdata (OptRecord _ _ _ rdata) = rdata
+getRdata ResourceRecord{..} = rdata
+getRdata OptRecord{..} = ordata
 
 -- | Raw data format for each type.
 data RData = RD_NS Domain

--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -5,6 +5,9 @@ module Network.DNS.Internal where
 
 import Control.Exception (Exception)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Builder as L
+import qualified Data.ByteString.Lazy as L
 import Data.IP (IP, IPv4, IPv6)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
@@ -235,11 +238,30 @@ data RData = RD_NS Domain
            | RD_OTH ByteString
            | RD_TLSA Word8 Word8 Word8 ByteString
            | RD_DS Word16 Word8 Word8 ByteString
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord)
 
 data OData = OD_ClientSubnet Word8 Word8 IP
            | OD_Unknown Int ByteString
     deriving (Eq,Show,Ord)
+
+instance Show RData where
+  show (RD_NS dom) = BS.unpack dom
+  show (RD_MX prf dom) = show prf ++ " " ++ BS.unpack dom
+  show (RD_CNAME dom) = BS.unpack dom
+  show (RD_DNAME dom) = BS.unpack dom
+  show (RD_A a) = show a
+  show (RD_AAAA aaaa) = show aaaa
+  show (RD_TXT txt) = BS.unpack txt
+  show (RD_SOA mn _ _ _ _ _ mi) = BS.unpack mn ++ " " ++ show mi
+  show (RD_PTR dom) = BS.unpack dom
+  show (RD_SRV pri wei prt dom) = show pri ++ " " ++ show wei ++ " " ++ show prt ++ BS.unpack dom
+  show (RD_OPT od) = show od
+  show (RD_OTH is) = show is
+  show (RD_TLSA use sel mtype dgst) = show use ++ " " ++ show sel ++ " " ++ show mtype ++ " " ++ hexencode dgst
+  show (RD_DS t a dt dv) = show t ++ " " ++ show a ++ " " ++ show dt ++ " " ++ hexencode dv
+
+hexencode :: ByteString -> String
+hexencode = BS.unpack . L.toStrict . L.toLazyByteString . L.byteStringHex
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -175,7 +175,7 @@ lookupMX rlv dom = do
 --   resolve their hostnames to IPv4 addresses by calling
 --   'lookupA'. The priorities are not retained.
 --
---   Examples:
+--   Examples (subject to bitrot as the IPs change from time to time):
 --
 --   >>> import Data.List (sort)
 --   >>> let hostname = Data.ByteString.Char8.pack "wide.ad.jp"
@@ -183,7 +183,7 @@ lookupMX rlv dom = do
 --   >>> rs <- makeResolvSeed defaultResolvConf
 --   >>> ips <- withResolver rs $ \resolver -> lookupAviaMX resolver hostname
 --   >>> fmap sort ips
---   Right [133.138.10.34,203.178.136.49]
+--   Right [133.138.10.39,203.178.136.30]
 --
 --   Since there is more than one result, it is necessary to sort the
 --   list in order to check for equality.

--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -42,7 +42,7 @@
 --   one millisecond:
 --
 --   >>> let hostname = Data.ByteString.Char8.pack "www.example.com"
---   >>> let badrc = defaultResolvConf { resolvTimeout = 1 }
+--   >>> let badrc = defaultResolvConf { resolvTimeout = 0 }
 --   >>>
 --   >>> rs <- makeResolvSeed badrc
 --   >>> withResolver rs $ \resolver -> lookupA resolver hostname

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | DNS Resolver and generic (lower-level) lookup functions.
 module Network.DNS.Resolver (
@@ -231,8 +233,8 @@ lookupSection section rlv dom typ = do
     dom' = if "." `isSuffixOf` dom then dom else dom ++ "."
     correct r = rrname r == dom' && rrtype r == typ
     -}
-    correct (ResourceRecord _ rrtype _ _) = rrtype == typ
-    correct (OptRecord _ _ _ _) = False
+    correct ResourceRecord{..} = rrtype == typ
+    correct OptRecord{..} = False
     toRData x = map getRdata . filter correct $ section x
 
 -- | Extract necessary information from 'DNSMessage'

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -262,7 +262,7 @@ fromDNSFormat = fromDNSMessage
 --   >>> let hostname = Data.ByteString.Char8.pack "www.example.com"
 --   >>> rs <- makeResolvSeed defaultResolvConf
 --   >>> withResolver rs $ \resolver -> lookup resolver hostname A
---   Right [RD_A 93.184.216.34]
+--   Right [93.184.216.34]
 --
 lookup :: Resolver -> Domain -> TYPE -> IO (Either DNSError [RData])
 lookup = lookupSection answer

--- a/dns.cabal
+++ b/dns.cabal
@@ -76,6 +76,7 @@ Test-Suite spec
   Main-Is:              Spec.hs
   Other-Modules:        EncodeSpec
                         DecodeSpec
+                        RoundTripSpec
   Build-Depends:        base
                       , attoparsec
                       , binary

--- a/dns.cabal
+++ b/dns.cabal
@@ -30,6 +30,7 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers
@@ -44,6 +45,7 @@ Library
                       , attoparsec
                       , binary
                       , bytestring
+                      , bytestring-builder
                       , conduit >= 1.1
                       , conduit-extra >= 1.1
                       , containers

--- a/dns.cabal
+++ b/dns.cabal
@@ -28,6 +28,7 @@ Library
   if impl(ghc >= 7)
     Build-Depends:      base >= 4 && < 5
                       , attoparsec
+                      , base64-bytestring
                       , binary
                       , bytestring
                       , bytestring-builder
@@ -43,6 +44,7 @@ Library
   else
     Build-Depends:      base >= 4 && < 5
                       , attoparsec
+                      , base64-bytestring
                       , binary
                       , bytestring
                       , bytestring-builder

--- a/test/EncodeSpec.hs
+++ b/test/EncodeSpec.hs
@@ -50,7 +50,7 @@ testQueryA = defaultQuery {
 testQueryAAAA :: DNSMessage
 testQueryAAAA = defaultQuery {
     header = defaultHeader {
-         identifier = 1001
+         identifier = 1000
        }
   , question = [makeQuestion "www.mew.org." AAAA]
   }
@@ -75,26 +75,93 @@ testResponseA = DNSMessage {
                    , qtype = A
                    }
                 ]
-  , answer =
-        [ ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [119, 147, 15, 122])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [119, 147, 79, 106])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [183, 60, 55, 43])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [183, 60, 55, 107])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [113, 108, 7, 172])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [113, 108, 7, 174])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [113, 108, 7, 175])
-        , ResourceRecord "492056364.qzone.qq.com." A 568 (RD_A $ toIPv4 [119, 147, 15, 100])
-        ]
-  , authority =
-        [ ResourceRecord "qzone.qq.com." NS 45919 (RD_NS "ns-tel2.qq.com.")
-        , ResourceRecord "qzone.qq.com." NS 45919 (RD_NS "ns-tel1.qq.com.")
-        ]
-  , additional =
-        [ ResourceRecord "ns-tel1.qq.com." A 46520 (RD_A $ toIPv4 [121, 14, 73, 115])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [222, 73, 76, 226])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [183, 60, 3, 202])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [218, 30, 72, 180])
-        ]
+  , answer = [ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [119, 147, 15, 122]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [119, 147, 79, 106]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [183, 60, 55, 43]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [183, 60, 55, 107]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [113, 108, 7, 172]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [113, 108, 7, 174]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [113, 108, 7, 175]
+                 }
+            , ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = A
+                 , rrttl = 568
+                 , rdata = RD_A $ toIPv4 [119, 147, 15, 100]
+                 }
+            ]
+  , authority = [ ResourceRecord {
+                       rrname = "qzone.qq.com."
+                     , rrtype = NS
+                     , rrttl = 45919
+                     , rdata = RD_NS "ns-tel2.qq.com."
+                     }
+                , ResourceRecord {
+                       rrname = "qzone.qq.com."
+                     , rrtype = NS
+                     , rrttl = 45919
+                     , rdata = RD_NS "ns-tel1.qq.com."
+                     }
+                ]
+  , additional = [ ResourceRecord {
+                        rrname = "ns-tel1.qq.com."
+                      , rrtype = A
+                      , rrttl = 46520
+                      , rdata = RD_A $ toIPv4 [121, 14, 73, 115]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [222, 73, 76, 226]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [183, 60, 3, 202]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [218, 30, 72, 180]
+                      }
+                 ]
   }
 
 testResponseTXT :: DNSMessage
@@ -117,17 +184,49 @@ testResponseTXT = DNSMessage {
                    , qtype = TXT
                    }
                 ]
-  , answer =
-        [ ResourceRecord "492056364.qzone.qq.com." TXT 0 (RD_TXT "simple txt line")
-        ]
-  , authority =
-        [ ResourceRecord "qzone.qq.com." NS 45919 (RD_NS "ns-tel2.qq.com.")
-        , ResourceRecord "qzone.qq.com." NS 45919 (RD_NS "ns-tel1.qq.com.")
-        ]
-  , additional =
-        [ ResourceRecord "ns-tel1.qq.com." A 46520 (RD_A $ toIPv4 [121, 14, 73, 115])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [222, 73, 76, 226])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [183, 60, 3, 202])
-        , ResourceRecord "ns-tel2.qq.com." A 2890 (RD_A $ toIPv4 [218, 30, 72, 180])
-        ]
+  , answer = [ResourceRecord {
+                   rrname = "492056364.qzone.qq.com."
+                 , rrtype = TXT
+                 , rrttl = 0
+                 , rdata = RD_TXT "simple txt line"
+                 }
+            ]
+  , authority = [ ResourceRecord {
+                       rrname = "qzone.qq.com."
+                     , rrtype = NS
+                     , rrttl = 45919
+                     , rdata = RD_NS "ns-tel2.qq.com."
+                     }
+                , ResourceRecord {
+                       rrname = "qzone.qq.com."
+                     , rrtype = NS
+                     , rrttl = 45919
+                     , rdata = RD_NS "ns-tel1.qq.com."
+                     }
+                ]
+  , additional = [ ResourceRecord {
+                        rrname = "ns-tel1.qq.com."
+                      , rrtype = A
+                      , rrttl = 46520
+                      , rdata = RD_A $ toIPv4 [121, 14, 73, 115]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [222, 73, 76, 226]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [183, 60, 3, 202]
+                      }
+                 , ResourceRecord {
+                        rrname = "ns-tel2.qq.com."
+                      , rrtype = A
+                      , rrttl = 2890
+                      , rdata = RD_A $ toIPv4 [218, 30, 72, 180]
+                      }
+                 ]
   }

--- a/test/RoundTripSpec.hs
+++ b/test/RoundTripSpec.hs
@@ -39,6 +39,11 @@ spec = do
         decodeDomain bs `shouldBe` Right dom
         fmap encodeDomain (decodeDomain bs) `shouldBe` Right bs
 
+    prop "Mailbox" . forAll genMailbox $ \ dom -> do
+        let bs = encodeMailbox dom
+        decodeMailbox bs `shouldBe` Right dom
+        fmap encodeMailbox (decodeMailbox bs) `shouldBe` Right bs
+
     prop "DNSFlags" . forAll genDNSFlags $ \ flgs -> do
         let bs = encodeDNSFlags flgs
         decodeDNSFlags bs `shouldBe` Right flgs
@@ -106,7 +111,7 @@ mkRData dom typ =
         TXT -> RD_TXT <$> genByteString
         MX -> RD_MX <$> genWord16 <*> genDomain
         CNAME -> pure $ RD_CNAME dom
-        SOA -> RD_SOA dom <$> genDomain <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32
+        SOA -> RD_SOA dom <$> genMailbox <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32 <*> genWord32
         PTR -> RD_PTR <$> genDomain
         SRV -> RD_SRV <$> genWord16 <*> genWord16 <*> genWord16 <*> genDomain
         DNAME -> RD_DNAME <$> genDomain
@@ -135,9 +140,18 @@ genByteString :: Gen BS.ByteString
 genByteString = elements
     [ "", "a", "a.b", "abc", "a.b.c" ]
 
+genMboxString :: Gen BS.ByteString
+genMboxString = elements
+    [ "", "a", "a@b", "abc", "a@b.c" ]
+
 genDomain :: Gen Domain
 genDomain = do
     bs <- genByteString
+    pure $ bs <> "."
+
+genMailbox :: Gen Mailbox
+genMailbox = do
+    bs <- genMboxString
     pure $ bs <> "."
 
 genDNSHeader :: Gen DNSHeader


### PR DESCRIPTION
This pull requests implements a more complete "show" for SOA records by properly displaying the "mrname" as an email address, and correctly displays cases where the first label contains an internal "." (first.last@domain).  It also subsumes PR #67 and PR #69 which are pre-requisites.

TODO: Even for (normail not mailbox) domains the encoder and decoder should be able to handle labels with embeded `.` characters, and when decoding escape these with a backslash per the presentation form specified in https://tools.ietf.org/html/rfc4343#section-2.1, when encoding the backslashes would need to suppress label breaks.