### PR TITLE
Fix sendAll on Windows

### DIFF
--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -183,7 +183,7 @@ lookupMX rlv dom = do
 --   >>> rs <- makeResolvSeed defaultResolvConf
 --   >>> ips <- withResolver rs $ \resolver -> lookupAviaMX resolver hostname
 --   >>> fmap sort ips
---   Right [133.138.10.34,203.178.136.49]
+--   Right [133.138.10.39,203.178.136.30]
 --
 --   Since there is more than one result, it is necessary to sort the
 --   list in order to check for equality.

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -19,6 +19,16 @@ module Network.DNS.Resolver (
   , fromDNSFormat
   ) where
 
+#if !defined(mingw32_HOST_OS)
+#define POSIX
+#else
+#define WIN
+#endif
+
+#if __GLASGOW_HASKELL__ < 709
+#define GHC6
+#endif
+
 import Control.Exception (bracket)
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
@@ -37,11 +47,11 @@ import Prelude hiding (lookup)
 import System.Random (getStdRandom, random)
 import System.Timeout (timeout)
 import Data.Word (Word16)
-#if __GLASGOW_HASKELL__ < 709
+#ifdef GHC6
 import Control.Applicative ((<$>), (<*>), pure)
 #endif
 
-#if mingw32_HOST_OS == 1
+#if defined(WIN) && defined(GHC6)
 import Network.Socket (send)
 import qualified Data.ByteString.Char8 as BS
 import Control.Monad (when)
@@ -440,12 +450,12 @@ tcpLookup query peer tm (Just vc) = do
         Nothing  -> return $ Left TimeoutExpired
         Just res -> return $ Right res
 
-#if mingw32_HOST_OS == 1
-    -- Windows does not support sendAll in Network.ByteString.
-    -- This implements sendAll with Haskell Strings.
-    sendAll sock bs = do
-	sent <- send sock (LB.unpack bs)
-	when (sent < fromIntegral (LB.length bs)) $ sendAll sock (LB.drop (fromIntegral sent) bs)
+#if defined(WIN) && defined(GHC6)
+-- Windows does not support sendAll in Network.ByteString for older GHCs.
+sendAll :: Socket -> BS.ByteString -> IO ()
+sendAll sock bs = do
+  sent <- send sock (BS.unpack bs)
+  when (sent < fromIntegral (BS.length bs)) $ sendAll sock (BS.drop (fromIntegral sent) bs)
 #endif
 
 isIllegal :: Domain -> Bool


### PR DESCRIPTION
This PR fixes some lookup problems Windows users were facing when
using the library. The culprit (as confirmed by some tests) was in
the implementation of `sendAll`, that on Windows was defined as part of
the code of this library, but this is not necessary anymore unless an
old version of GHC (< 7) is being used.

For modern environments, `Network.Socket.ByteString.sendAll` is all we
need.