### PR TITLE
Fixed #50 (TimeoutExpired fired too soon)

### DIFF
--- a/Network/DNS/Internal.hs
+++ b/Network/DNS/Internal.hs
@@ -105,6 +105,8 @@ data DNSError =
     -- | The sequence number of the answer doesn't match our query. This
     --   could indicate foul play.
     SequenceNumberMismatch
+    -- | The number of retries for the request was exceeded.
+  | RetryLimitExceeded
     -- | The request simply timed out.
   | TimeoutExpired
     -- | The answer has the correct sequence number, but returned an

--- a/Network/DNS/Lookup.hs
+++ b/Network/DNS/Lookup.hs
@@ -39,14 +39,14 @@
 --
 --   The only error that we can easily cause is a timeout. We do this
 --   by creating and utilizing a 'ResolvConf' which has a timeout of
---   one millisecond:
+--   one millisecond and a very limited number of retries:
 --
 --   >>> let hostname = Data.ByteString.Char8.pack "www.example.com"
---   >>> let badrc = defaultResolvConf { resolvTimeout = 1 }
+--   >>> let badrc = defaultResolvConf { resolvTimeout = 1, resolvRetry = 1 }
 --   >>>
 --   >>> rs <- makeResolvSeed badrc
 --   >>> withResolver rs $ \resolver -> lookupA resolver hostname
---   Left TimeoutExpired
+--   Left RetryLimitExceeded
 --
 --   As is the convention, successful results will always be wrapped
 --   in a 'Right', while errors will be wrapped in a 'Left'.
@@ -183,7 +183,7 @@ lookupMX rlv dom = do
 --   >>> rs <- makeResolvSeed defaultResolvConf
 --   >>> ips <- withResolver rs $ \resolver -> lookupAviaMX resolver hostname
 --   >>> fmap sort ips
---   Right [133.138.10.34,203.178.136.49]
+--   Right [133.138.10.39,203.178.136.30]
 --
 --   Since there is more than one result, it is necessary to sort the
 --   list in order to check for equality.

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -361,7 +361,7 @@ lookupRawInternal rcv ad rlv dom typ = do
     loop query checkSeqno cnt mismatch
       | cnt == retry = do
           let ret | mismatch  = SequenceNumberMismatch
-                  | otherwise = TimeoutExpired
+                  | otherwise = RetryLimitExceeded
           return $ Left ret
       | otherwise    = do
           sendAll sock query

--- a/dns.cabal
+++ b/dns.cabal
@@ -1,5 +1,5 @@
 Name:                   dns
-Version:                2.0.10
+Version:                2.0.12
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.9
+resolver: lts-9.1
 
 packages:
 - '.'


### PR DESCRIPTION
This PR does a number of things:

* Bumps the `stackage` revision to `lts-9.1` in `stack.yaml` as without it `stack test` was not running due to build plain failure;

* Bumps the cabal version number in the manifest (everybody seems to have his own preference, not fussed about this one and I can revert, I will leave @kazu-yamamoto decides what he likes best);

* Adds a new constructor to `DNSError` named `RetryLimitExceeded`, using it when appropriate;

* Fixes the doctests