### PR TITLE
Fixed #80 (support multiple nameservers)

### DIFF
--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -31,6 +31,7 @@ module Network.DNS.Resolver (
 #endif
 
 import Control.Exception (bracket, throwIO)
+import Control.Monad (forM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import Data.Char (isSpace)
@@ -39,6 +40,8 @@ import Data.Maybe (fromMaybe)
 import Data.Word (Word16)
 import Network.BSD (getProtocolNumber)
 import Network.DNS.Decode
+import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty (NonEmpty(..))
 import Network.DNS.Encode
 import Network.DNS.Types
 import Network.Socket (AddrInfoFlag(..), AddrInfo(..), SockAddr(..), Family(AF_INET, AF_INET6), PortNumber(..), HostName, Socket, SocketType(Stream, Datagram), close, socket, connect, getPeerName, getAddrInfo, defaultHints, defaultProtocol)
@@ -123,19 +126,19 @@ defaultResolvConf = ResolvConf {
 -- | Abstract data type of DNS Resolver seed.
 --   When implementing a DNS cache, this should be re-used.
 data ResolvSeed = ResolvSeed {
-    addrInfo :: AddrInfo
-  , rsTimeout :: Int
-  , rsRetry :: Int
-  , rsBufsize :: Integer
+    nameservers :: NonEmpty AddrInfo
+  , rsTimeout   :: Int
+  , rsRetry     :: Int
+  , rsBufsize   :: Integer
 }
 
 -- | Abstract data type of DNS Resolver
 --   When implementing a DNS cache, this MUST NOT be re-used.
 data Resolver = Resolver {
-    genId   :: IO Word16
-  , dnsSock :: Socket
+    genId      :: IO Word16
+  , dnsSocks   :: NonEmpty Socket
   , dnsTimeout :: Int
-  , dnsRetry :: Int
+  , dnsRetry   :: Int
   , dnsBufsize :: Integer
 }
 
@@ -149,31 +152,35 @@ data Resolver = Resolver {
 --    >>> rs <- makeResolvSeed defaultResolvConf
 --
 makeResolvSeed :: ResolvConf -> IO ResolvSeed
-makeResolvSeed conf = ResolvSeed <$> addr
-                                 <*> pure (resolvTimeout conf)
-                                 <*> pure (resolvRetry conf)
-                                 <*> pure (resolvBufsize conf)
+makeResolvSeed conf = do
+  let tm      = resolvTimeout conf
+  let retry   = resolvRetry conf
+  let bufSize = resolvBufsize conf
+  nameservers <- findAddresses
+  return $ ResolvSeed nameservers tm retry bufSize
   where
-    addr = case resolvInfo conf of
-        RCHostName numhost -> makeAddrInfo numhost Nothing
-        RCHostPort numhost mport -> makeAddrInfo numhost $ Just mport
+    findAddresses :: IO (NonEmpty AddrInfo)
+    findAddresses = case resolvInfo conf of
+        RCHostName numhost       -> (:| []) <$> (makeAddrInfo numhost Nothing)
+        RCHostPort numhost mport -> (:| []) <$> (makeAddrInfo numhost (Just mport))
         RCFilePath file -> do
-            ms <- getDefaultDnsServer file
-            case ms of
-              Nothing -> throwIO BadConfiguration
-              Just s  -> makeAddrInfo s Nothing
+            nss <- getDefaultDnsServers file
+            case nss of
+              []     -> throwIO BadConfiguration
+              (l:ls) -> (:|) <$> (makeAddrInfo l Nothing) <*> forM ls (flip makeAddrInfo Nothing)
 
-getDefaultDnsServer :: FilePath -> IO (Maybe String)
+getDefaultDnsServers :: FilePath -> IO [String]
 #if defined(WIN)
-getDefaultDnsServer _ = getWindowsDefDnsServer >>= maybePeek peekCString
+getDefaultDnsServers _ = do
+  res <- getWindowsDefDnsServer >>= maybePeek peekCString
+  return $ maybe mempty (: []) res
 
 foreign import ccall "getWindowsDefDnsServer" getWindowsDefDnsServer :: IO CString
 #else
-getDefaultDnsServer file = toAddr <$> readFile file
+getDefaultDnsServers file = toAddresses <$> readFile file
   where
-    toAddr cs = case filter ("nameserver" `isPrefixOf`) $ lines cs of
-      []  -> Nothing
-      l:_ -> Just $ extract l
+    toAddresses :: String -> [String]
+    toAddresses cs = map extract (filter ("nameserver" `isPrefixOf`) (lines cs))
     extract = reverse . dropWhile isSpace . reverse . dropWhile isSpace . drop 11
 #endif
 
@@ -202,37 +209,33 @@ makeAddrInfo addr mport = do
 --   'Resolver'. If multiple 'Resolver's are necessary for
 --   concurrent purpose, use 'withResolvers'.
 withResolver :: ResolvSeed -> (Resolver -> IO a) -> IO a
-withResolver seed func = bracket (openSocket seed) close $ \sock -> do
-    connectSocket sock seed
-    func $ makeResolver seed sock
+withResolver seed f = bracket (initSockets seed) (mapM_ close) (f . makeResolver seed)
 
 -- | Giving thread-safe 'Resolver's to the function of the second
 --   argument. Sockets for UDP are opened inside and are surely closed.
 --   For each 'Resolver', multiple lookups must be done sequentially.
 --   'Resolver's can be used concurrently.
 withResolvers :: [ResolvSeed] -> ([Resolver] -> IO a) -> IO a
-withResolvers seeds func = bracket openSockets closeSockets $ \socks -> do
-    mapM_ (uncurry connectSocket) $ zip socks seeds
+withResolvers seeds func = bracket (mapM initSockets seeds) closeSockets $ \socks -> do
     let resolvs = zipWith makeResolver seeds socks
     func resolvs
   where
-    openSockets = mapM openSocket seeds
-    closeSockets = mapM close
+    closeSockets = mapM_ close . concatMap NE.toList
 
-openSocket :: ResolvSeed -> IO Socket
-openSocket seed = socket (addrFamily ai) (addrSocketType ai) (addrProtocol ai)
+-- | Atomically create and connect to all the nameservers listed in the given
+-- `ResolvSeed`.
+initSockets :: ResolvSeed -> IO (NonEmpty Socket)
+initSockets seed = mapM initSocket addrs
   where
-    ai = addrInfo seed
+    initSocket ai = do sock <- socket (addrFamily ai) (addrSocketType ai) (addrProtocol ai)
+                       connect sock (addrAddress ai)
+                       return sock
+    addrs         = nameservers seed
 
-connectSocket :: Socket -> ResolvSeed -> IO ()
-connectSocket sock seed = connect sock (addrAddress ai)
-  where
-    ai = addrInfo seed
-
-makeResolver :: ResolvSeed -> Socket -> Resolver
-makeResolver seed sock = Resolver {
+makeResolver :: ResolvSeed -> NonEmpty Socket -> Resolver
+makeResolver seed socks = Resolver {
     genId = getRandom
-  , dnsSock = sock
+  , dnsSocks = socks
   , dnsTimeout = rsTimeout seed
   , dnsRetry = rsRetry seed
   , dnsBufsize = rsBufsize seed
@@ -406,7 +409,7 @@ lookupRawInternal rcv ad rlv dom typ = do
                       True | not $ trunCation $ flags $ header res
                              -> return $ Right res
                       _      -> tcpRetry query sock tm
-    sock = dnsSock rlv
+    sock = NE.head (dnsSocks rlv)
     tm = dnsTimeout rlv
     retry = dnsRetry rlv
     q = Question dom typ

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -41,7 +41,7 @@ module Network.DNS.Types (
   ) where
 
 
-import Control.Exception (Exception)
+import Control.Exception (Exception, IOException)
 import Data.Bits ((.&.), shiftR, testBit)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as B64 (encode)
@@ -195,6 +195,7 @@ data DNSError =
   | BadOptRecord
     -- | Configuration is wrong.
   | BadConfiguration
+  | NetworkFailure IOException
   deriving (Eq, Show, Typeable)
 
 instance Exception DNSError

--- a/dns.cabal
+++ b/dns.cabal
@@ -25,6 +25,8 @@ Library
                         Network.DNS.Encode
                         Network.DNS.Decode
   Other-Modules:        Network.DNS.StateBinary
+  if impl(ghc < 8)
+    Build-Depends:      semigroups
   if impl(ghc >= 7)
     Build-Depends:      base >= 4 && < 5
                       , attoparsec


### PR DESCRIPTION
Hey @kazu-yamamoto !

Incidentally this also fixes #28.

I've bite the bullet and I have opened the PR. My colleague @kantp confirms this patch effectively fixes his problems.

The gist of this patch:

* A `ResolvSeed` has been extended with a `NonEmpty AddrInfo`. Why `NonEmpty`? Because the contract here is that we need to ensure _at least_ one `AddrInfo` is in scope, and using a simple list won't capture it. `NonEmpty` is not exposed to user's code, it's only for internal safety.

* I have removed the `connectSocket` function, because it was too much of a degree of freedom. Now given a `ResolvSeed` you get back a `NonEmpty Socket` where all the sockets inside are correctly opened and connected.

* A `Resolver` keeps internally a `NonEmpty Socket`, one for each nameserver, which can be tried iteratively in case (say) the primary DNS does not work.

* `lookupRawInternal` has been refactored (just a bit) to try all the different nameservers, catching all the exceptions with a `try` block.

Let me know what you think!