### PR TITLE
Use `drop 1` instead of `tail`

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -208,7 +208,7 @@ getRData CNAME _ = RD_CNAME <$> getDomain
 getRData DNAME _ = RD_DNAME <$> getDomain
 getRData TXT len = (RD_TXT . ignoreLength) <$> getNByteString len
   where
-    ignoreLength = BS.tail
+    ignoreLength = BS.drop 1
 getRData A len
   | len == 4  = (RD_A . toIPv4) <$> getNBytes len
   | otherwise = fail "IPv4 addresses must be 4 bytes long"


### PR DESCRIPTION
This fixes the TXT  parser so that it does not fail on empty input.

I have an additional question regarding the semantics of `StateBinary.getNByteString` -- is the position in `SGet` meant to track the logical position or the number of bytes actually consumed? For example, `getNByteString 10` will consume only 5 bytes if fed a 5 byte input but the resulting offset inside the `SGet` would be 10, which seems incorrect to me.