### PR TITLE
Remove minttl and cosmetic fixes

### DIFF
--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -138,7 +138,7 @@ insertPositive CacheConf{..} c k v ttl = when (ttl /= 0) $ do
     tim <- addUTCTime life <$> getCurrentTime
     insertCache k tim v c
   where
-    life = fromIntegral (minimumTTL `max` (maximumTTL `min` ttl))
+    life = fromIntegral (maximumTTL `min` ttl)
 
 cacheNegative :: CacheConf -> Cache -> Key -> Entry -> DNSMessage -> IO ()
 cacheNegative cconf c key v ans = case soas of

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -20,7 +20,6 @@ module Network.DNS.Resolver (
   -- ** Configuring cache
   , CacheConf
   , defaultCacheConf
-  , minimumTTL
   , maximumTTL
   , pruningDelay
   -- * Intermediate data type for resolver

--- a/Network/DNS/Types/Internal.hs
+++ b/Network/DNS/Types/Internal.hs
@@ -27,20 +27,18 @@ data FileOrNumericHost = RCFilePath FilePath -- ^ A path for \"resolv.conf\"
 
 -- | Cache configuration for responses.
 data CacheConf = CacheConf {
-    -- | If RR's TTL is lower than this value, this value is used instead.
-    minimumTTL  :: TTL
     -- | If RR's TTL is higher than this value, this value is used instead.
-  , maximumTTL  :: TTL
-    -- | Dealy of pruning in second.
+    maximumTTL  :: TTL
+    -- | Cache pruning interval in seconds.
   , pruningDelay  :: Int
   } deriving Show
 
 -- | Default cache configuration.
 --
 -- >>> defaultCacheConf
--- CacheConf {minimumTTL = 60, maximumTTL = 300, pruningDelay = 10}
+-- CacheConf {maximumTTL = 300, pruningDelay = 10}
 defaultCacheConf :: CacheConf
-defaultCacheConf = CacheConf 60 300 10
+defaultCacheConf = CacheConf 300 10
 
 ----------------------------------------------------------------
 
@@ -59,7 +57,7 @@ defaultCacheConf = CacheConf 60 300 10
 --
 --  >>> let conf = defaultResolvConf { resolvEDNS = [] }
 --
---  An example to disable EDNS0 with a 1,280-bytes buffer:
+--  An example to enable EDNS0 with a 1,280-bytes buffer:
 --
 --  >>> let conf = defaultResolvConf { resolvEDNS = [fromEDNS0 defaultEDNS0 { udpSize = 1280 }] }
 --


### PR DESCRIPTION
I don't think there should be a minimum TTL.  If we get a TTL less than 60s, we should either honour it or not cache the data, but we should not raise the received TTL.  My preference is to honour whatever TTL we get.