### PR TITLE
Improving decoder

### DIFF
--- a/Network/DNS/Decode.hs
+++ b/Network/DNS/Decode.hs
@@ -20,12 +20,12 @@ import Network.DNS.Types
 
 -- | Decoding DNS query or response.
 
-decode :: ByteString -> Either String DNSMessage
+decode :: ByteString -> Either DNSError DNSMessage
 decode bs = fst <$> runSGet getResponse bs
 
 -- | Parse many length-encoded DNS records, for example, from TCP traffic.
 
-decodeMany :: ByteString -> Either String ([DNSMessage], ByteString)
+decodeMany :: ByteString -> Either DNSError ([DNSMessage], ByteString)
 decodeMany bs = do
     ((bss, _), leftovers) <- runSGetWithLeftovers lengthEncoded bs
     msgs <- mapM decode bss
@@ -38,21 +38,21 @@ decodeMany bs = do
       getNByteString len
 
 -- | Decoding DNS flags.
-decodeDNSFlags :: ByteString -> Either String DNSFlags
+decodeDNSFlags :: ByteString -> Either DNSError DNSFlags
 decodeDNSFlags bs = fst <$> runSGet getDNSFlags bs
 
 -- | Decoding DNS header.
-decodeDNSHeader :: ByteString -> Either String DNSHeader
+decodeDNSHeader :: ByteString -> Either DNSError DNSHeader
 decodeDNSHeader bs = fst <$> runSGet getHeader bs
 
 -- | Decoding domain.
-decodeDomain :: ByteString -> Either String Domain
+decodeDomain :: ByteString -> Either DNSError Domain
 decodeDomain bs = fst <$> runSGet getDomain bs
 
 -- | Decoding mailbox.
-decodeMailbox :: ByteString -> Either String Mailbox
+decodeMailbox :: ByteString -> Either DNSError Mailbox
 decodeMailbox bs = fst <$> runSGet getMailbox bs
 
 -- | Decoding resource record.
-decodeResourceRecord :: ByteString -> Either String ResourceRecord
+decodeResourceRecord :: ByteString -> Either DNSError ResourceRecord
 decodeResourceRecord bs = fst <$> runSGet getResourceRecord bs

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -233,7 +233,7 @@ getMailbox = do
 getDomain' :: Char -> Int -> Int -> SGet ByteString
 getDomain' sep1 lim loopcnt
   -- 127 is the logical limitation of pointers.
-  | loopcnt >= 127 = fail "too deep pointers"
+  | loopcnt >= 127 = fail "pointer recursion limit exceeded"
   | otherwise      = do
       pos <- getPosition
       c <- getInt8

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -240,9 +240,11 @@ getDomain' sep1 = do
             let offset = n * 256 + d
             mo <- pop offset
             case mo of
-                Nothing -> fail $ "getDomain: " ++ show offset
-                -- A pointer may refer to another pointer.
-                -- So, register this position for the domain.
+                Nothing -> do
+                    inp <- getInput
+                    case runSGet getDomain (B.drop offset inp) of
+                      Left str -> fail str
+                      Right o -> push pos (fst o) >> return (fst o)
                 Just o -> push pos o >> return o
         -- As for now, extended labels have no use.
         -- This may change some time in the future.

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -241,7 +241,7 @@ getDomain' sep1 = do
             case mo of
                 Nothing -> do
                     inp <- getInput
-                    case runSGet getDomain (B.drop offset inp) of
+                    case runSGet (getDomain' sep1) (B.drop offset inp) of
                       Left (DecodeError err) -> fail err
                       Left err               -> fail $ show err
                       Right o  -> push pos (fst o) >> return (fst o)

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -242,8 +242,9 @@ getDomain' sep1 = do
                 Nothing -> do
                     inp <- getInput
                     case runSGet getDomain (B.drop offset inp) of
-                      Left str -> fail str
-                      Right o -> push pos (fst o) >> return (fst o)
+                      Left (DecodeError err) -> fail err
+                      Left err               -> fail $ show err
+                      Right o  -> push pos (fst o) >> return (fst o)
                 Just o -> push pos o >> return o
         -- As for now, extended labels have no use.
         -- This may change some time in the future.

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -256,10 +256,9 @@ getDomain' sep1 pointerStack = do
         _ -> do
             hs <- getNByteString n
             ds <- getDomain' '.' []
-            let dom =
-                    case ds of -- avoid trailing ".."
-                        "." -> hs `BS.append` "."
-                        _   -> hs `BS.append` BS.singleton sep1 `BS.append` ds
+            let dom = case ds of -- avoid trailing ".."
+                    "." -> hs `BS.append` "."
+                    _   -> hs `BS.append` BS.singleton sep1 `BS.append` ds
             push pos dom
             return dom
   where

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -33,7 +33,6 @@ getResponse = do
                   <*> getResourceRecords nsCount
                   <*> getResourceRecords arCount
 
-
 ----------------------------------------------------------------
 
 getDNSFlags :: SGet DNSFlags
@@ -83,8 +82,8 @@ getOptCode = toOptCode <$> get16
 
 getQuery :: SGet Question
 getQuery = Question <$> getDomain
-                       <*> getTYPE
-                       <*  ignoreClass
+                    <*> getTYPE
+                    <*  ignoreClass
 
 getResourceRecords :: Int -> SGet [ResourceRecord]
 getResourceRecords n = replicateM n getResourceRecord

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -255,7 +255,7 @@ getDomain' sep1 pointerStack = do
         _ | isExtLabel c -> return ""
         _ -> do
             hs <- getNByteString n
-            ds <- getDomain' '.' []
+            ds <- getDomain' '.' pointerStack
             let dom = case ds of -- avoid trailing ".."
                     "." -> hs `BS.append` "."
                     _   -> hs `BS.append` BS.singleton sep1 `BS.append` ds

--- a/Network/DNS/IO.hs
+++ b/Network/DNS/IO.hs
@@ -55,7 +55,8 @@ import Network.DNS.Types
 
 receive :: Socket -> IO DNSMessage
 receive sock = do
-    bs <- recv sock 4096 `E.catch` \e -> E.throwIO $ NetworkFailure e
+    let bufsiz = fromIntegral maxUdpSize
+    bs <- recv sock bufsiz `E.catch` \e -> E.throwIO $ NetworkFailure e
     case decode bs of
         Left  e   -> E.throwIO e
         Right msg -> return msg

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -353,6 +353,7 @@ data DNSError =
     -- | Network failure.
   | NetworkFailure IOException
     -- | Error is unknown
+  | DecodeError String
   | UnknownDNSError
   deriving (Eq, Show, Typeable)
 

--- a/dns.cabal
+++ b/dns.cabal
@@ -63,10 +63,12 @@ Test-Suite network
   Ghc-Options:          -Wall
   Main-Is:              Spec.hs
   Other-Modules:        LookupSpec
+                        IOSpec
   Build-Depends:        dns
                       , base
                       , bytestring
                       , hspec
+                      , network
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0

--- a/dns.cabal
+++ b/dns.cabal
@@ -41,8 +41,6 @@ Library
                       , base64-bytestring
                       , binary
                       , bytestring
-                      , conduit >= 1.1
-                      , conduit-extra >= 1.1
                       , containers
                       , cryptonite
                       , iproute >= 1.3.2

--- a/test/DecodeSpec.hs
+++ b/test/DecodeSpec.hs
@@ -56,13 +56,16 @@ spec = do
 
 tripleDecodeTest :: ByteString -> IO ()
 tripleDecodeTest hexbs =
-    ecase (decode $ fromHexString hexbs) fail $ \ x1 ->
-        ecase (decode $ encode x1) fail $ \ x2 ->
-            ecase (decode $ encode x2) fail $ \ x3 ->
+    ecase (decode $ fromHexString hexbs) fail' $ \ x1 ->
+        ecase (decode $ encode x1) fail' $ \ x2 ->
+            ecase (decode $ encode x2) fail' $ \ x3 ->
                 x3 `shouldBe` x2
+  where
+    fail' (DecodeError err) = fail err
+    fail' _                 = error "fail'"
 
 ecase :: Either a b -> (a -> c) -> (b -> c) -> c
-ecase (Left a) f _ = f a
+ecase (Left  a) f _ = f a
 ecase (Right b) _ g = g b
 
 ----------------------------------------------------------------

--- a/test2/IOSpec.hs
+++ b/test2/IOSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module IOSpec where
+
+import Network.DNS.IO as DNS
+import Network.DNS.Types as DNS
+import Network.Socket hiding (send)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "send/receive" $ do
+
+    it "resolves well with UDP" $ do
+        let hints = defaultHints { addrFamily = AF_INET, addrSocketType = Datagram, addrFlags = [AI_NUMERICHOST]}
+        addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
+        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+        connect sock $ addrAddress addr
+        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] False
+        send sock qry
+        ans <- receive sock
+        identifier (header ans) `shouldBe` 1
+
+    it "resolves well with TCP" $ do
+        let hints = defaultHints { addrFamily = AF_INET, addrSocketType = Stream, addrFlags = [AI_NUMERICHOST]}
+        addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
+        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+        connect sock $ addrAddress addr
+        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] False
+        sendVC sock qry
+        ans <- receiveVC sock
+        identifier (header ans) `shouldBe` 1


### PR DESCRIPTION
I hope this PR fixes #103 and #107.

- The decoder now holds the original input and can parse domains even if the structure of the target record is unknown. See #103 for more information. Note that I have not implemented `RRSIG`.
- The decoder now throws `DNSError` to fix #107. I'm sorry but it appeared that the `RD_PARSERR` approach is very difficult.

@benclifford and @vdukhovni Would you review this PR?