### PR TITLE
Drop unexpected UDP answers

### DIFF
--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -80,6 +80,9 @@ getTYPE = toTYPE <$> get16
 getOptCode :: SGet OptCode
 getOptCode = toOptCode <$> get16
 
+-- XXX: Include the class when implemented, or otherwise perhaps check the
+-- implicit assumption that the class is classIN.
+--
 getQuery :: SGet Question
 getQuery = Question <$> getDomain
                     <*> getTYPE

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -98,10 +98,12 @@ putDNSFlags DNSFlags{..} = put16 word
 
     word = execState st 0
 
+-- XXX: Use question class when implemented
+--
 putQuestion :: Question -> SPut
 putQuestion Question{..} = putDomain qname
                            <> put16 (fromTYPE qtype)
-                           <> put16 1
+                           <> put16 classIN
 
 putResourceRecord :: ResourceRecord -> SPut
 putResourceRecord ResourceRecord{..} = mconcat [

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -600,6 +600,8 @@ toRCODEforHeader w = toRCODE (w .&. 0x0f)
 
 ----------------------------------------------------------------
 
+-- XXX: The Question really should also include the CLASS
+--
 -- | Raw data format for DNS questions.
 data Question = Question {
     qname  :: Domain -- ^ A domain name


### PR DESCRIPTION
Occassionally, when a client gives on a query and closes its UDP
socket, the nameserver nevertheless eventually replies.  When that
happens, the UDP socket in question may now be in use for a different
query.  When the unexpected stale answer arrives, we should just
drop it, and continue waiting for the right answer.  Otherwise, we
may end up with spurious sequence number mismatch errors (observed
in practice under heavy load, with thousands of DNS queries per
second).

We check both the sequence number and the question.  For this the
question domain needs to be in standard form, with a trailing '.'.
We might have checked the question class, but questions are at
present implicitly in class "IN".  Sprinkled in some comments in
case that ever changes.

Turned the question into a singleton list early, simplifying
downsream code.