### PR TITLE
Make use of the RD and CD bits configurable

### DIFF
--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -52,6 +52,7 @@ getDNSFlags = do
                         (getRecAvailable flgs)
                         rc
                         (getAuthenData flgs)
+                        (getChkDisable flgs)
     getQorR w = if testBit w 15 then QR_Response else QR_Query
     getOpcode w = toOPCODE (shiftR w 11 .&. 0x0f)
     getAuthAnswer w = testBit w 10
@@ -60,6 +61,7 @@ getDNSFlags = do
     getRecAvailable w = testBit w 7
     getRcode w = toRCODEforHeader $ fromIntegral w
     getAuthenData w = testBit w 5
+    getChkDisable w = testBit w 4
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -84,6 +84,7 @@ putDNSFlags DNSFlags{..} = put16 word
     st :: State Word16 ()
     st = sequence_
               [ set (fromIntegral $ fromRCODEforHeader rcode)
+              , when chkDisable          $ set (bit 4)
               , when authenData          $ set (bit 5)
               , when recAvailable        $ set (bit 7)
               , when recDesired          $ set (bit 8)

--- a/Network/DNS/IO.hs
+++ b/Network/DNS/IO.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.DNS.IO (
-    -- * Receiving from socket
+    -- * Receiving DNS messages
     receive
   , receiveVC
-    -- * Sending to socket
+    -- * Sending pre-encoded messages
   , send
   , sendVC
     -- ** Encoding queries for transmission
@@ -13,7 +13,7 @@ module Network.DNS.IO (
   , encodeQuestions'
   , composeQuery
   , composeQueryAD
-    -- ** Creating Response
+    -- ** Creating query response messages
   , responseA
   , responseAAAA
   ) where

--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -4,8 +4,9 @@ module Network.DNS.LookupRaw (
   -- * Looking up functions
     lookup
   , lookupAuth
-  -- * Raw looking up function
+  -- * Lookups returning DNS Messages
   , lookupRaw
+  , lookupRaw'
   , lookupRawAD
   , fromDNSMessage
   , fromDNSFormat
@@ -227,7 +228,7 @@ isTypeOf t ResourceRecord{..} = rrtype == t
 --  @
 --
 lookupRaw :: Resolver -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
-lookupRaw rslv dom typ = resolve dom typ rslv False receive
+lookupRaw rslv dom typ = resolve dom typ rslv mempty receive
 
 -- | Same as 'lookupRaw' but the query sets the AD bit, which solicits the
 --   the authentication status in the server reply.  In most applications
@@ -236,7 +237,18 @@ lookupRaw rslv dom typ = resolve dom typ rslv False receive
 --   interface should in most cases only be used with a loopback resolver.
 --
 lookupRawAD :: Resolver -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
-lookupRawAD rslv dom typ = resolve dom typ rslv True receive
+lookupRawAD rslv dom typ = resolve dom typ rslv (adBit (Just True)) receive
+
+-- | Similar to 'lookupRawAD' but the query-related flag bits are specified
+-- via a 'QueryFlags' combination of overrides, which are generated as a
+-- 'Monoid' by the 'rdBit', 'adBit' and 'cdBit' combinators.
+--
+lookupRaw' :: Resolver   -- ^ Resolver obtained via 'withResolver'
+           -> Domain     -- ^ Query domain
+           -> TYPE       -- ^ Query RRtype
+           -> QueryFlags -- ^ RD, AD and CD flags
+           -> IO (Either DNSError DNSMessage)
+lookupRaw' rslv dom typ fl = resolve dom typ rslv fl receive
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -14,6 +14,7 @@ module Network.DNS.Resolver (
   , resolvEDNS
   , resolvConcurrent
   , resolvCache
+  , resolvQueryFlags
   -- ** Specifying DNS servers
   , FileOrNumericHost(..)
   -- ** Configuring cache

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -52,8 +52,19 @@ module Network.DNS.Types (
   -- ** DNS Header
   , DNSHeader (..)
   , Identifier
+  -- *** DNS flags
+  , DNSFlags (..)
   , QorR (..)
+  , defaultDNSFlags
+  , QueryFlags
+  , queryDNSFlags
+  , rdBit
+  , adBit
+  , cdBit
+  -- **** OPCODE and RCODE
   , OPCODE (..)
+  , fromOPCODE
+  , toOPCODE
   , RCODE (
     NoErr
   , FormatErr
@@ -68,17 +79,6 @@ module Network.DNS.Types (
   , NotZone
   , BadOpt
   )
-  -- *** DNS flags
-  , DNSFlags (..)
-  , defaultDNSFlags
-  , QueryFlags
-  , queryDNSFlags
-  , rdBit
-  , adBit
-  , cdBit
-  -- **** OPCODE and RCODE
-  , fromOPCODE
-  , toOPCODE
   , fromRCODE
   , toRCODE
   , fromRCODEforHeader
@@ -443,6 +443,8 @@ defaultDNSFlags = DNSFlags
 -- yield all possible combinations of "set", "clear" and "reset" (to default)
 -- for each of the bits.
 --
+-- ==== __Example__
+--
 -- >>> :{
 -- let setrd = rdBit (Just True)
 --     setad = adBit (Just True)
@@ -542,6 +544,8 @@ data OPCODE
   | OP_UPDATE -- ^ An update request (RFC2136)
   deriving (Eq, Show, Enum, Bounded)
 
+-- | Convert a 16-bit DNS OPCODE number to its internal representation
+--
 toOPCODE :: Word16 -> Maybe OPCODE
 toOPCODE i = case i of
   0 -> Just OP_STD
@@ -551,6 +555,9 @@ toOPCODE i = case i of
   5 -> Just OP_UPDATE
   _ -> Nothing
 
+-- | Convert the internal representation of a DNS OPCODE to its 16-bit numeric
+-- value.
+--
 fromOPCODE :: OPCODE -> Word16
 fromOPCODE OP_STD    = 0
 fromOPCODE OP_INV    = 1

--- a/Network/DNS/Types/Internal.hs
+++ b/Network/DNS/Types/Internal.hs
@@ -63,6 +63,19 @@ defaultCacheConf = CacheConf 300 10
 --  An example to enable cache:
 --
 --  >>> let conf = defaultResolvConf { resolvCache = Just defaultCacheConf }
+--
+-- An example to disable requesting recursive service.
+--
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = rdBit (Just False) }
+--
+-- An example to set the AD bit in all queries by default.
+--
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = adBit (Just True) }
+--
+-- An example to set the both the AD and CD bits in all queries by default.
+--
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = adBit (Just True) <> cdBit (Just True) }
+--
 data ResolvConf = ResolvConf {
    -- | Server information.
     resolvInfo       :: FileOrNumericHost
@@ -76,6 +89,11 @@ data ResolvConf = ResolvConf {
   , resolvConcurrent :: Bool
    -- | Cache configuration.
   , resolvCache      :: Maybe CacheConf
+   -- | Overrides for the default flags used for queries via resolvers that use
+   -- this configuration.  The overrides are generated as a 'Monoid' by the
+   -- 'rdBit', 'adBit' and 'cdBit' combinators.  The AD and CD bits are
+   -- typically only useful when recursion is not disabled.
+  , resolvQueryFlags :: QueryFlags
 } deriving Show
 
 -- | Return a default 'ResolvConf':
@@ -86,6 +104,7 @@ data ResolvConf = ResolvConf {
 -- * 'resolvEDNS' is EDNS0 with a 4,096-bytes buffer.
 -- * 'resolvConcurrent' is False.
 -- * 'resolvCache' is Nothing.
+-- * 'resolvQueryFlags' is an empty set of overrides.
 defaultResolvConf :: ResolvConf
 defaultResolvConf = ResolvConf {
     resolvInfo       = RCFilePath "/etc/resolv.conf"
@@ -94,6 +113,7 @@ defaultResolvConf = ResolvConf {
   , resolvEDNS       = [fromEDNS0 defaultEDNS0]
   , resolvConcurrent = False
   , resolvCache      = Nothing
+  , resolvQueryFlags = mempty
 }
 
 ----------------------------------------------------------------

--- a/test/EncodeSpec.hs
+++ b/test/EncodeSpec.hs
@@ -68,6 +68,7 @@ testResponseA = DNSMessage {
          , recAvailable = True
          , rcode = NoErr
          , authenData = False
+         , chkDisable = False
          }
        }
   , question = [Question {
@@ -110,6 +111,7 @@ testResponseTXT = DNSMessage {
          , recAvailable = True
          , rcode = NoErr
          , authenData = False
+         , chkDisable = False
          }
        }
   , question = [Question {

--- a/test/RoundTripSpec.hs
+++ b/test/RoundTripSpec.hs
@@ -148,7 +148,7 @@ genDNSHeader = DNSHeader <$> genWord16 <*> genDNSFlags
 genDNSFlags :: Gen DNSFlags
 genDNSFlags =
   DNSFlags <$> genQorR <*> genOPCODE <*> genBool <*> genBool
-            <*> genBool <*> genBool <*> genRCODE <*> genBool
+           <*> genBool <*> genBool <*> genRCODE <*> genBool <*> genBool
 
 genWord16 :: Gen Word16
 genWord16 = arbitrary

--- a/test2/IOSpec.hs
+++ b/test2/IOSpec.hs
@@ -2,6 +2,7 @@
 
 module IOSpec where
 
+import Data.Monoid ((<>))
 import Network.DNS.IO as DNS
 import Network.DNS.Types as DNS
 import Network.Socket hiding (send)
@@ -15,7 +16,9 @@ spec = describe "send/receive" $ do
         addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
-        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] False
+        -- Google's resolvers support the AD and CD bits
+        let qry = encodeQuestions' 1 [Question "www.mew.org" A] [] $
+                  rdBit (Just True) <> adBit (Just True) <> cdBit (Just True)
         send sock qry
         ans <- receive sock
         identifier (header ans) `shouldBe` 1
@@ -25,7 +28,8 @@ spec = describe "send/receive" $ do
         addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
-        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] False
+        let qry = encodeQuestions' 1 [Question "www.mew.org" A] [] $
+                  rdBit (Just True) <> adBit (Just False) <> cdBit (Just True)
         sendVC sock qry
         ans <- receiveVC sock
         identifier (header ans) `shouldBe` 1


### PR DESCRIPTION
This can be done at the resolver level by setting default values for
new ResolvConf fields.  This makes it possible to request unvalidated
data from validating DNSSEC resolvers (by setting the CD bit) or
to query authoritative servers (by clearing the RD bit, since many
authoritative servers will refuse queries with the RD bit set, even
when authoritative for the query domain).

Alternatively, the new "lookupRaw'" function takes a "QueryFlags"
parameter which is a "newtype" around DNFlags with a hidden
constructor.  The "mkQueryFlags" function returns a "QueryFlags"
record in which only query-related flags can be modified.  The
"fromQueryFlags" accessor gives us back the contructed "DNSFlags".

With these changes one can configure per-resolver defaults for the
RD/AD/CD bits, or else choose settings on the fly for each lookup
with "lookupRaw'".  (This makes "lookupRawAD" somewhat obsolete,
we might deprecate it at some point in the future, but probably
best to leave it be, it is simpler if one just wants the AD bit).