### PR TITLE
defining defaultQueryFlags, flagSet, flagClear and FlagReset.

### DIFF
--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -233,12 +233,10 @@ lookupRaw :: Resolver   -- ^ Resolver obtained via 'withResolver'
           -> Domain     -- ^ Query domain
           -> TYPE       -- ^ Query RRtype
           -> IO (Either DNSError DNSMessage)
-lookupRaw rslv dom typ = lookupRawWithFlags rslv dom typ mempty
+lookupRaw rslv dom typ = lookupRawWithFlags rslv dom typ defaultQueryFlags
 
 -- | Similar to 'lookupRaw' but the query-related flag bits are specified
--- via a 'QueryFlags' combination of overrides, which are generated as a
--- 'Monoid' by the 'rdFlag', 'adFlag' and 'cdFlag' combinators.
---
+-- via a 'QueryFlags'.
 lookupRawWithFlags :: Resolver   -- ^ Resolver obtained via 'withResolver'
                    -> Domain     -- ^ Query domain
                    -> TYPE       -- ^ Query RRtype

--- a/Network/DNS/Transport.hs
+++ b/Network/DNS/Transport.hs
@@ -80,8 +80,8 @@ resolve dom typ rlv qfl rcv
     seed    = resolvseed rlv
     nss     = NE.toList $ nameservers seed
     onlyOne = length nss == 1
-    fl      = qfl <> resolvQueryFlags (resolvconf $ resolvseed rlv)
-
+    qfl0    = resolvQueryFlags (resolvconf $ resolvseed rlv)
+    fl      = qfl0 `combineQueryFlags` qfl
     conf       = resolvconf seed
     concurrent = resolvConcurrent conf
     tm         = resolvTimeout conf

--- a/Network/DNS/Types/Internal.hs
+++ b/Network/DNS/Types/Internal.hs
@@ -66,15 +66,15 @@ defaultCacheConf = CacheConf 300 10
 --
 -- An example to disable requesting recursive service.
 --
---  >>> let conf = defaultResolvConf { resolvQueryFlags = rdFlag FlagClear }
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = defaultQueryFlags `flagClear` FlagRD }
 --
 -- An example to set the AD bit in all queries by default.
 --
---  >>> let conf = defaultResolvConf { resolvQueryFlags = adFlag FlagSet }
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = defaultQueryFlags `flagSet` FlagAD }
 --
 -- An example to set the both the AD and CD bits in all queries by default.
 --
---  >>> let conf = defaultResolvConf { resolvQueryFlags = adFlag FlagSet <> cdFlag FlagSet }
+--  >>> let conf = defaultResolvConf { resolvQueryFlags = defaultQueryFlags `flagSet` FlagAD `flagSet` FlagCD }
 --
 data ResolvConf = ResolvConf {
    -- | Server information.
@@ -90,9 +90,7 @@ data ResolvConf = ResolvConf {
    -- | Cache configuration.
   , resolvCache      :: Maybe CacheConf
    -- | Overrides for the default flags used for queries via resolvers that use
-   -- this configuration.  The overrides are generated as a 'Monoid' by the
-   -- 'rdFlag', 'adFlag' and 'cdFlag' combinators.  The AD and CD bits are
-   -- typically only useful when recursion is not disabled.
+   -- this configuration.
   , resolvQueryFlags :: QueryFlags
 } deriving Show
 
@@ -113,7 +111,7 @@ defaultResolvConf = ResolvConf {
   , resolvEDNS       = [fromEDNS0 defaultEDNS0]
   , resolvConcurrent = False
   , resolvCache      = Nothing
-  , resolvQueryFlags = mempty
+  , resolvQueryFlags = defaultQueryFlags
 }
 
 ----------------------------------------------------------------

--- a/test2/IOSpec.hs
+++ b/test2/IOSpec.hs
@@ -2,7 +2,6 @@
 
 module IOSpec where
 
-import Data.Monoid ((<>))
 import Network.DNS.IO as DNS
 import Network.DNS.Types as DNS
 import Network.Socket hiding (send)
@@ -17,8 +16,8 @@ spec = describe "send/receive" $ do
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
         -- Google's resolvers support the AD and CD bits
-        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] $
-                  rdFlag FlagSet <> adFlag FlagSet <> cdFlag FlagSet
+        let qflags = defaultQueryFlags `flagSet` FlagRD `flagSet` FlagAD `flagSet` FlagCD
+            qry = encodeQuestions 1 [Question "www.mew.org" A] [] qflags
         send sock qry
         ans <- receive sock
         identifier (header ans) `shouldBe` 1
@@ -28,8 +27,8 @@ spec = describe "send/receive" $ do
         addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
-        let qry = encodeQuestions 1 [Question "www.mew.org" A] [] $
-                  rdFlag FlagSet <> adFlag FlagClear <> cdFlag FlagSet
+        let qflags = defaultQueryFlags `flagSet` FlagRD `flagClear` FlagAD `flagSet` FlagCD
+            qry = encodeQuestions 1 [Question "www.mew.org" A] [] qflags
         sendVC sock qry
         ans <- receiveVC sock
         identifier (header ans) `shouldBe` 1


### PR DESCRIPTION
To fix #119, `defaultQueryFlags` is defined. Users can set/clear/reset like this:

```
defaultQueryFlags `flagSet` FlagRD `flagSet` FlagAD `flagSet` FlagCD
```

@vdukhovni Two isseus:

- Do you like this?
- Should we hide `combineQueryFlags` and `queryDNSFlags`?