### PR TITLE
Edns overhaul

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # 3.1.0
 
+* Breaking change: EDNS0 is renamed to EDNS.
 * Breaking change: lookupRawAD, composeQuery, composeQueryAD are removed.
 * A new API: lookupRawWithFlags, QueryFlags, FlagOp, rdFlag, adFlag, cdFlag,
   and resolvQueryFlags. [#116](https://github.com/kazu-yamamoto/dns/pull/116)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # 3.1.0
 
+* Decoding of the ClientSubnet option is now a total function,
+  provided the RDATA is structurally sound.  Unexpected values
+  just yield OD_ECSgeneric results.
+* Breaking change: New OD_ECSgeneric EDNS constructor, represents
+  ClientSubnet values whose address family is not IP or that violate
+  the specification.  The "family" field distinguishes the two cases.
+* The ClientSubnet EDNS option is now encoded correctly even when the
+  source bits match some trailing all-zero bytes.
 * Breaking change: EDNS0 is renamed to EDNS.
 * Breaking change: lookupRawAD, composeQuery, composeQueryAD are removed.
 * A new API: lookupRawWithFlags, QueryFlags, FlagOp, rdFlag, adFlag, cdFlag,

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # 3.1.0
 
+* Added EDNS OPTIONS: NSID, DAU, DHU, N3U
 * Decoding of the ClientSubnet option is now a total function,
   provided the RDATA is structurally sound.  Unexpected values
   just yield OD_ECSgeneric results.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,23 @@
 # 3.1.0
 
+- TCP queries now also use EDNS, since the DO bit and other options
+  may be relevant, even when the UDP buffer size is not.  Therefore,
+  TCP now also does a non-EDNS fallback.
+- The resolvEDNS field is subsumed in resolvQueryControls and
+  removed.  The encodeQuestion function changes to no longer take
+  an explicit "EDNSheader" argument, instead the EDNS record is
+  built based on the supplied options.  Also the encodeQuestions
+  function has been removed, since we're deprecating it, but the
+  legacy interface can no longer be maintained.
+- New API: doFlag, ednsEnable, ednsSetVersion, ednsSetSize and
+  ednsSetOptions makes it possible for 'QueryControls' to adjust
+  EDNS settings.
+- Renamed:
+
+    resolvQueryFlags   -> resolvQueryControls,
+    lookupRawWithFlags -> lookupRawCtl
+    QueryFlags         -> QueryControls
+
 - Breaking change: the decoded EDNS record no longer contains
   an error field.  Instead the header of decoded messages is
   updated hold the extended error code when valid EDNS OPT records

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,52 @@
 # 3.1.0
 
-* Added EDNS OPTIONS: NSID, DAU, DHU, N3U
-* Decoding of the ClientSubnet option is now a total function,
+- Breaking change: the decoded EDNS record no longer contains
+  an error field.  Instead the header of decoded messages is
+  updated hold the extended error code when valid EDNS OPT records
+  (EDNS pseudo-headers) are found.  The remaining EDNS record
+  fields have been renamed:
+
+        udpSize  -> ednsBufferSize
+        dnssecOk -> ednsDnssecOk
+        options  -> ednsOptions
+
+  The reverse process happens on output with the 12-bit header
+  RCODE split across the wire-form DNS header and the OPT record.
+  When EDNS is not enabled, and the RCODE > 15, it is mapped to
+  FormatErr instead.
+- Breaking change: The fromRCODEforHeader and toRCODEforHeader
+  functions have been removed.
+- The fromDNSMessage function now distinguishes between FormatErr
+  responses without an OPT record (which signal no EDNS support),
+  and FormatErr with an OPT record, which signal problems
+  (malformed or unsupported version) with the OPT record received
+  in the request.  For the latter the 'BadOptRecord' error is
+  returned.
+- Added more RCODEs, including a BadRCODE that is generated
+  locally, rather than parsed from the message.  The value
+  lies just above the EDNS 12-bit range, with the bottom
+  12-bits matching FormatErr.
+- Breaking change: The DNSMessage structure now has an
+  "ednsHeader" field, initialized to "EDNSheader defaultEDNS"
+  in "defaultQuery" and to "NoEDNS" in "defaultResponse".
+  The former enables EDNS(0) with default options, the latter
+  leaves EDNS unconfigured.
+- The BadOpt RCODE is renamed to BadVers to better resemble
+  the term used in RFCs.
+- Added EDNS OPTIONS: NSID, DAU, DHU, N3U
+- Decoding of the ClientSubnet option is now a total function,
   provided the RDATA is structurally sound.  Unexpected values
   just yield OD_ECSgeneric results.
-* Breaking change: New OD_ECSgeneric EDNS constructor, represents
+- Breaking change: New OD_ECSgeneric EDNS constructor, represents
   ClientSubnet values whose address family is not IP or that violate
   the specification.  The "family" field distinguishes the two cases.
-* The ClientSubnet EDNS option is now encoded correctly even when the
+- The ClientSubnet EDNS option is now encoded correctly even when the
   source bits match some trailing all-zero bytes.
-* Breaking change: EDNS0 is renamed to EDNS.
-* Breaking change: lookupRawAD, composeQuery, composeQueryAD are removed.
-* A new API: lookupRawWithFlags, QueryFlags, FlagOp, rdFlag, adFlag, cdFlag,
+- Breaking change: EDNS0 is renamed to EDNS.
+- Breaking change: lookupRawAD, composeQuery, composeQueryAD are removed.
+- A new API: lookupRawWithFlags, QueryFlags, FlagOp, rdFlag, adFlag, cdFlag,
   and resolvQueryFlags. [#116](https://github.com/kazu-yamamoto/dns/pull/116)
-* New OP codes: OP_NOTIFY and OP_UPDATE.
+- New OP codes: OP_NOTIFY and OP_UPDATE.
   [#113](https://github.com/kazu-yamamoto/dns/pull/113)
 
 # 3.0.4

--- a/Network/DNS.hs
+++ b/Network/DNS.hs
@@ -4,7 +4,7 @@
 --   convenience.
 --   Applications will most likely use the high-level interface, while
 --   library/daemon authors may need to use the lower-level one.
---   EDNS0 and TCP fallback are supported.
+--   EDNS and TCP fallback are supported.
 --
 --   Examples:
 --

--- a/Network/DNS/Decode/Internal.hs
+++ b/Network/DNS/Decode/Internal.hs
@@ -208,6 +208,10 @@ getRData NSEC3PARAM len = RD_NSEC3PARAM <$> decodeHashAlg
 getRData _  len = UnknownRData <$> getNByteString len
 
 getOData :: OptCode -> Int -> SGet OData
+getOData NSID len = OD_NSID          <$> getNByteString len
+getOData DAU  len = OD_DAU. B.unpack <$> getNByteString len
+getOData DHU  len = OD_DHU. B.unpack <$> getNByteString len
+getOData N3U  len = OD_N3U. B.unpack <$> getNByteString len
 getOData ClientSubnet len = do
         family  <- get16
         srcBits <- get8

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -52,23 +52,45 @@ encodeResourceRecord rr = runSPut $ putResourceRecord rr
 ----------------------------------------------------------------
 
 putDNSMessage :: DNSMessage -> SPut
-putDNSMessage msg = putHeader hdr
+putDNSMessage msg = putHeader hd
                     <> putNums
                     <> mconcat (map putQuestion qs)
                     <> mconcat (map putResourceRecord an)
                     <> mconcat (map putResourceRecord au)
                     <> mconcat (map putResourceRecord ad)
   where
-    putNums = mconcat $ fmap putInt16 [length qs
-                                         ,length an
-                                         ,length au
-                                         ,length ad
-                                         ]
-    hdr = header msg
+    putNums = mconcat $ fmap putInt16 [ length qs
+                                      , length an
+                                      , length au
+                                      , length ad
+                                      ]
+    hm = header msg
+    fl = flags hm
+    eh = ednsHeader msg
     qs = question msg
     an = answer msg
     au = authority msg
-    ad = additional msg
+    hd = ifEDNS eh hm $ hm { flags = fl { rcode = rc } }
+    rc = ifEDNS eh <$> id <*> nonEDNSrcode $ rcode fl
+      where
+        nonEDNSrcode code | fromRCODE code < 16 = code
+                          | otherwise           = FormatErr
+    ad = prependOpt $ additional msg
+      where
+        prependOpt ads = mapEDNS eh (fromEDNS ads $ fromRCODE rc) ads
+          where
+            fromEDNS :: AdditionalRecords -> Word16 -> EDNS -> AdditionalRecords
+            fromEDNS rrs rc' edns = ResourceRecord name' type' class' ttl' rdata' : rrs
+              where
+                name'  = BS.singleton '.'
+                type'  = OPT
+                class' = maxUdpSize `min` (minUdpSize `max` ednsUdpSize edns)
+                ttl0'  = fromIntegral (rc' .&. 0xff0) `shiftL` 20
+                vers'  = fromIntegral (ednsVersion edns) `shiftL` 16
+                ttl'
+                  | ednsDnssecOk edns = ttl0' `setBit` 15 .|. vers'
+                  | otherwise         = ttl0' .|. vers'
+                rdata' = RD_OPT $ ednsOptions edns
 
 putHeader :: DNSHeader -> SPut
 putHeader hdr = putIdentifier (identifier hdr)
@@ -84,7 +106,7 @@ putDNSFlags DNSFlags{..} = put16 word
 
     st :: State Word16 ()
     st = sequence_
-              [ set (fromIntegral $ fromRCODEforHeader rcode)
+              [ set (fromRCODE rcode .&. 0x0f)
               , when chkDisable          $ set (bit 4)
               , when authenData          $ set (bit 5)
               , when recAvailable        $ set (bit 7)

--- a/Network/DNS/Encode.hs
+++ b/Network/DNS/Encode.hs
@@ -175,6 +175,14 @@ putRData rd = case rd of
         ]
     UnknownRData bytes -> putByteString bytes
 
+-- | Encode EDNS OPTION consisting of a list of octets.
+putODWords :: Word16 -> [Word8] -> SPut
+putODWords code ws =
+     mconcat [ put16 code
+             , putInt16 $ length ws
+             , mconcat $ map put8 ws
+             ]
+
 -- | Encode an EDNS OPTION byte string.
 putODBytes :: Word16 -> ByteString -> SPut
 putODBytes code bs =
@@ -184,6 +192,10 @@ putODBytes code bs =
             ]
 
 putOData :: OData -> SPut
+putOData (OD_NSID nsid) = putODBytes (fromOptCode NSID) nsid
+putOData (OD_DAU as) = putODWords (fromOptCode DAU) as
+putOData (OD_DHU hs) = putODWords (fromOptCode DHU) hs
+putOData (OD_N3U hs) = putODWords (fromOptCode N3U) hs
 putOData (OD_ClientSubnet srcBits scpBits ip) =
     -- https://tools.ietf.org/html/rfc7871#section-6
     --

--- a/Network/DNS/IO.hs
+++ b/Network/DNS/IO.hs
@@ -135,10 +135,10 @@ sendAll sock bs = do
 --
 encodeQuestion :: Identifier
                 -> Question
-                -> AdditionalRecords -- ^ Additional RRs for EDNS.
-                -> QueryFlags        -- ^ Custom RD\/AD\/CD flags.
+                -> EDNSheader -- ^ Optional EDNS
+                -> QueryFlags -- ^ Custom RD\/AD\/CD flags.
                 -> ByteString
-encodeQuestion idt q adds fs = encode $ makeQuery idt q adds fs
+encodeQuestion idt q eh fs = encode $ makeQuery idt q eh fs
 
 -- | The encoded 'DNSMessage' has the specified request ID.  The default values
 -- of the RD, AD and CD flag bits may be updated via the 'QueryFlags'
@@ -151,15 +151,15 @@ encodeQuestion idt q adds fs = encode $ makeQuery idt q adds fs
 --
 encodeQuestions :: Identifier
                 -> [Question]
-                -> AdditionalRecords -- ^ Additional RRs for EDNS.
-                -> QueryFlags        -- ^ Custom RD\/AD\/CD flags.
+                -> EDNSheader -- ^ Optional EDNS
+                -> QueryFlags -- ^ Custom RD\/AD\/CD flags.
                 -> ByteString
-encodeQuestions idt qs adds fs = encode $ empqry {
+encodeQuestions idt qs eh fs = encode $ empqry {
       header = (header empqry) { identifier = idt }
     , question = qs
     }
   where
-    empqry = makeEmptyQuery adds fs
+    empqry = makeEmptyQuery eh fs
 
 {-# DEPRECATED encodeQuestions "Use encodeQuestion instead" #-}
 

--- a/Network/DNS/IO.hs
+++ b/Network/DNS/IO.hs
@@ -10,7 +10,6 @@ module Network.DNS.IO (
   , sendVC
     -- ** Encoding queries for transmission
   , encodeQuestion
-  , encodeQuestions
     -- ** Creating query response messages
   , responseA
   , responseAAAA
@@ -125,43 +124,17 @@ sendAll sock bs = do
 #endif
 
 -- | The encoded 'DNSMessage' has the specified request ID.  The default values
--- of the RD, AD and CD flag bits may be updated via the 'QueryFlags'
--- parameter.  A suitable combination of flags can be created via the 'rdFlag',
--- 'adFlag' and 'cdFlag' generators of the 'Network.DNS.Types.QueryFlags'
--- 'Monoid'.
+-- of the RD, AD, CD and DO flag bits, as well as various EDNS features, can be
+-- adjusted via the 'QueryControls' parameter.
 --
 -- The caller is responsible for generating the ID via a securely seeded
 -- CSPRNG.
 --
-encodeQuestion :: Identifier
-                -> Question
-                -> EDNSheader -- ^ Optional EDNS
-                -> QueryFlags -- ^ Custom RD\/AD\/CD flags.
+encodeQuestion :: Identifier     -- ^ Crypto random request id
+                -> Question      -- ^ Query name and type
+                -> QueryControls -- ^ Query flag and EDNS overrides
                 -> ByteString
-encodeQuestion idt q eh fs = encode $ makeQuery idt q eh fs
-
--- | The encoded 'DNSMessage' has the specified request ID.  The default values
--- of the RD, AD and CD flag bits may be updated via the 'QueryFlags'
--- parameter.  A suitable combination of flags can be created via the 'rdFlag',
--- 'adFlag' and 'cdFlag' generators of the 'Network.DNS.Types.QueryFlags'
--- 'Monoid'.
---
--- The caller is responsible for generating the ID via a securely seeded
--- CSPRNG.
---
-encodeQuestions :: Identifier
-                -> [Question]
-                -> EDNSheader -- ^ Optional EDNS
-                -> QueryFlags -- ^ Custom RD\/AD\/CD flags.
-                -> ByteString
-encodeQuestions idt qs eh fs = encode $ empqry {
-      header = (header empqry) { identifier = idt }
-    , question = qs
-    }
-  where
-    empqry = makeEmptyQuery eh fs
-
-{-# DEPRECATED encodeQuestions "Use encodeQuestion instead" #-}
+encodeQuestion idt q ctls = encode $ makeQuery idt q ctls
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -168,15 +168,15 @@ isTypeOf t ResourceRecord{..} = rrtype == t
 --    a new identifier is created atomically from the cryptographically
 --    secure pseudo random number generator for the target DNS server.
 --    Then UDP queries are tried with the limitation of 'resolvRetry'
---    (use EDNS0 if specifiecd).
---    If it appear that the target DNS server does not support EDNS0,
+--    (use EDNS if specifiecd).
+--    If it appears that the target DNS server does not support EDNS,
 --    it falls back to traditional queries.
 --
 --  * If the response is truncated, a new TCP socket bound to a new
---    locla port is created. Then exactly one TCP query is retried.
+--    local port is created. Then exactly one TCP query is retried.
 --
 --
--- If multiple DNS server are specified 'ResolvConf' ('RCHostNames ')
+-- If multiple DNS servers are specified 'ResolvConf' ('RCHostNames ')
 -- or found ('RCFilePath'), either sequential lookup or
 -- concurrent lookup is carried out:
 --

--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -267,7 +267,8 @@ fromDNSMessage ans conv = case errcode ans of
     NameErr   -> Left NameError
     NotImpl   -> Left NotImplemented
     Refused   -> Left OperationRefused
-    BadOpt    -> Left BadOptRecord
+    BadVers   -> Left BadOptRecord
+    BadRCODE  -> Left $ DecodeError "Malformed EDNS message"
     _         -> Left UnknownDNSError
   where
     errcode = rcode . flags . header

--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -6,7 +6,7 @@ module Network.DNS.LookupRaw (
   , lookupAuth
   -- * Lookups returning DNS Messages
   , lookupRaw
-  , lookupRawWithFlags
+  , lookupRawCtl
   -- * DNS Message procesing
   , fromDNSMessage
   , fromDNSFormat
@@ -160,7 +160,6 @@ isTypeOf t ResourceRecord{..} = rrtype == t
 ----------------------------------------------------------------
 
 -- | Look up a name and return the entire DNS Response.
--- Flags: RD: 'True', AD: 'False', CD: 'False'.
 --
 -- For a given DNS server, the queries are done:
 --
@@ -233,18 +232,18 @@ lookupRaw :: Resolver   -- ^ Resolver obtained via 'withResolver'
           -> Domain     -- ^ Query domain
           -> TYPE       -- ^ Query RRtype
           -> IO (Either DNSError DNSMessage)
-lookupRaw rslv dom typ = lookupRawWithFlags rslv dom typ mempty
+lookupRaw rslv dom typ = lookupRawCtl rslv dom typ mempty
 
--- | Similar to 'lookupRaw' but the query-related flag bits are specified
--- via a 'QueryFlags' combination of overrides, which are generated as a
--- 'Monoid' by the 'rdFlag', 'adFlag' and 'cdFlag' combinators.
+-- | Similar to 'lookupRaw', but the default values of the RD, AD, CD and DO
+-- flag bits, as well as various EDNS features, can be adjusted via the
+-- 'QueryControls' parameter.
 --
-lookupRawWithFlags :: Resolver   -- ^ Resolver obtained via 'withResolver'
-                   -> Domain     -- ^ Query domain
-                   -> TYPE       -- ^ Query RRtype
-                   -> QueryFlags -- ^ RD, AD and CD flags
-                   -> IO (Either DNSError DNSMessage)
-lookupRawWithFlags rslv dom typ fl = resolve dom typ rslv fl receive
+lookupRawCtl :: Resolver      -- ^ Resolver obtained via 'withResolver'
+             -> Domain        -- ^ Query domain
+             -> TYPE          -- ^ Query RRtype
+             -> QueryControls -- ^ Query flag and EDNS overrides
+             -> IO (Either DNSError DNSMessage)
+lookupRawCtl rslv dom typ ctls = resolve dom typ rslv ctls receive
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Memo.hs
+++ b/Network/DNS/Memo.hs
@@ -72,5 +72,12 @@ copy (RD_NSEC3PARAM a b c salt) = RD_NSEC3PARAM a b c $ B.copy salt
 copy (UnknownRData is)    = UnknownRData $ B.copy is
 
 copyOData :: OData -> OData
-copyOData o@(OD_ClientSubnet _ _ _) = o
+copyOData (OD_ECSgeneric family srcBits scpBits bs) =
+    OD_ECSgeneric family srcBits scpBits $ B.copy bs
 copyOData (UnknownOData c b)        = UnknownOData c $ B.copy b
+
+-- No copying required for the rest, but avoiding a wildcard pattern match
+-- so that if more option types are added in the future, the compiler will
+-- complain about a partial function.
+--
+copyOData o@(OD_ClientSubnet {}) = o

--- a/Network/DNS/Memo.hs
+++ b/Network/DNS/Memo.hs
@@ -74,6 +74,7 @@ copy (UnknownRData is)    = UnknownRData $ B.copy is
 copyOData :: OData -> OData
 copyOData (OD_ECSgeneric family srcBits scpBits bs) =
     OD_ECSgeneric family srcBits scpBits $ B.copy bs
+copyOData (OD_NSID nsid) = OD_NSID $ B.copy nsid
 copyOData (UnknownOData c b)        = UnknownOData c $ B.copy b
 
 -- No copying required for the rest, but avoiding a wildcard pattern match
@@ -81,3 +82,6 @@ copyOData (UnknownOData c b)        = UnknownOData c $ B.copy b
 -- complain about a partial function.
 --
 copyOData o@(OD_ClientSubnet {}) = o
+copyOData o@(OD_DAU {}) = o
+copyOData o@(OD_DHU {}) = o
+copyOData o@(OD_N3U {}) = o

--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -11,10 +11,9 @@ module Network.DNS.Resolver (
   , resolvInfo
   , resolvTimeout
   , resolvRetry
-  , resolvEDNS
   , resolvConcurrent
   , resolvCache
-  , resolvQueryFlags
+  , resolvQueryControls
   -- ** Specifying DNS servers
   , FileOrNumericHost(..)
   -- ** Configuring cache

--- a/Network/DNS/Types/Internal.hs
+++ b/Network/DNS/Types/Internal.hs
@@ -54,11 +54,11 @@ defaultCacheConf = CacheConf 300 10
 --
 --  An example to disable EDNS:
 --
---  >>> let conf = defaultResolvConf { resolvEDNS = [] }
+--  >>> let conf = defaultResolvConf { resolvEDNS = NoEDNS }
 --
 --  An example to enable EDNS(0) with a 1,280-bytes buffer:
 --
---  >>> let conf = defaultResolvConf { resolvEDNS = [fromEDNS defaultEDNS { udpSize = 1280 }] }
+--  >>> let conf = defaultResolvConf { resolvEDNS = EDNSheader $ defaultEDNS { ednsUdpSize = 1280 } }
 --
 --  An example to enable cache:
 --
@@ -84,7 +84,7 @@ data ResolvConf = ResolvConf {
    -- | The number of retries including the first try.
   , resolvRetry      :: Int
    -- | Additional resource records to specify EDNS.
-  , resolvEDNS       :: AdditionalRecords
+  , resolvEDNS       :: EDNSheader
    -- | Concurrent queries if multiple DNS servers are specified.
   , resolvConcurrent :: Bool
    -- | Cache configuration.
@@ -110,7 +110,7 @@ defaultResolvConf = ResolvConf {
     resolvInfo       = RCFilePath "/etc/resolv.conf"
   , resolvTimeout    = 3 * 1000 * 1000
   , resolvRetry      = 3
-  , resolvEDNS       = [fromEDNS defaultEDNS]
+  , resolvEDNS       = EDNSheader defaultEDNS
   , resolvConcurrent = False
   , resolvCache      = Nothing
   , resolvQueryFlags = mempty

--- a/Network/DNS/Types/Internal.hs
+++ b/Network/DNS/Types/Internal.hs
@@ -52,13 +52,13 @@ defaultCacheConf = CacheConf 300 10
 --
 --  >>> let conf = defaultResolvConf { resolvInfo = RCHostNames ["8.8.8.8","8.8.4.4"], resolvConcurrent = True }
 --
---  An example to disable EDNS0:
+--  An example to disable EDNS:
 --
 --  >>> let conf = defaultResolvConf { resolvEDNS = [] }
 --
---  An example to enable EDNS0 with a 1,280-bytes buffer:
+--  An example to enable EDNS(0) with a 1,280-bytes buffer:
 --
---  >>> let conf = defaultResolvConf { resolvEDNS = [fromEDNS0 defaultEDNS0 { udpSize = 1280 }] }
+--  >>> let conf = defaultResolvConf { resolvEDNS = [fromEDNS defaultEDNS { udpSize = 1280 }] }
 --
 --  An example to enable cache:
 --
@@ -101,7 +101,7 @@ data ResolvConf = ResolvConf {
 -- * 'resolvInfo' is 'RCFilePath' \"\/etc\/resolv.conf\".
 -- * 'resolvTimeout' is 3,000,000 micro seconds.
 -- * 'resolvRetry' is 3.
--- * 'resolvEDNS' is EDNS0 with a 4,096-bytes buffer.
+-- * 'resolvEDNS' is EDNS(0) with a 4,096-bytes buffer.
 -- * 'resolvConcurrent' is False.
 -- * 'resolvCache' is Nothing.
 -- * 'resolvQueryFlags' is an empty set of overrides.
@@ -110,7 +110,7 @@ defaultResolvConf = ResolvConf {
     resolvInfo       = RCFilePath "/etc/resolv.conf"
   , resolvTimeout    = 3 * 1000 * 1000
   , resolvRetry      = 3
-  , resolvEDNS       = [fromEDNS0 defaultEDNS0]
+  , resolvEDNS       = [fromEDNS defaultEDNS]
   , resolvConcurrent = False
   , resolvCache      = Nothing
   , resolvQueryFlags = mempty

--- a/test/EncodeSpec.hs
+++ b/test/EncodeSpec.hs
@@ -71,6 +71,7 @@ testResponseA = DNSMessage {
          , chkDisable = False
          }
        }
+  , ednsHeader = NoEDNS
   , question = [Question {
                      qname = "492056364.qzone.qq.com."
                    , qtype = A
@@ -114,6 +115,7 @@ testResponseTXT = DNSMessage {
          , chkDisable = False
          }
        }
+  , ednsHeader = EDNSheader defaultEDNS
   , question = [Question {
                      qname = "492056364.qzone.qq.com."
                    , qtype = TXT

--- a/test2/IOSpec.hs
+++ b/test2/IOSpec.hs
@@ -17,7 +17,7 @@ spec = describe "send/receive" $ do
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
         -- Google's resolvers support the AD and CD bits
-        let qry = encodeQuestion 1 (Question "www.mew.org" A) [] $
+        let qry = encodeQuestion 1 (Question "www.mew.org" A) NoEDNS $
                   rdFlag FlagSet <> adFlag FlagSet <> cdFlag FlagSet
         send sock qry
         ans <- receive sock
@@ -28,7 +28,7 @@ spec = describe "send/receive" $ do
         addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
-        let qry = encodeQuestion 1 (Question "www.mew.org" A) [] $
+        let qry = encodeQuestion 1 (Question "www.mew.org" A) (EDNSheader defaultEDNS) $
                   rdFlag FlagSet <> adFlag FlagClear <> cdFlag FlagSet
         sendVC sock qry
         ans <- receiveVC sock

--- a/test2/IOSpec.hs
+++ b/test2/IOSpec.hs
@@ -17,8 +17,8 @@ spec = describe "send/receive" $ do
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
         -- Google's resolvers support the AD and CD bits
-        let qry = encodeQuestion 1 (Question "www.mew.org" A) NoEDNS $
-                  rdFlag FlagSet <> adFlag FlagSet <> cdFlag FlagSet
+        let qry = encodeQuestion 1 (Question "www.mew.org" A) $
+                  adFlag FlagSet <> ednsEnabled FlagClear
         send sock qry
         ans <- receive sock
         identifier (header ans) `shouldBe` 1
@@ -28,8 +28,8 @@ spec = describe "send/receive" $ do
         addr:_ <- getAddrInfo (Just hints) (Just "8.8.8.8") (Just "domain")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock $ addrAddress addr
-        let qry = encodeQuestion 1 (Question "www.mew.org" A) (EDNSheader defaultEDNS) $
-                  rdFlag FlagSet <> adFlag FlagClear <> cdFlag FlagSet
+        let qry = encodeQuestion 1 (Question "www.mew.org" A) $
+                  adFlag FlagClear <> cdFlag FlagSet <> doFlag FlagSet
         sendVC sock qry
         ans <- receiveVC sock
         identifier (header ans) `shouldBe` 1


### PR DESCRIPTION
The five commits in this pull request change a lot of code.  Each builds on the previous one, and the code should build and test after each step (1, 1 + 2, 1 + 2 + 3, ...).

It may be easier to review the commits one at a time, and see fewer changes at a given time, with better focus on a particular set of issues.

On the other hand the combined set of patches change some pieces of code multiple times.  So it is perhaps more "effiecient" to review everything at once, if it is not too much to take in.

If you'd prefer a series of 5 pull requests, we could start with commit 1, get that done, then review 2, ...

My advice is to clone the branch, and review on your own machine with "git diff -U20" (or however much context you prefer), and then go to github only to make comments on anything you find.

Once all these changes are done, we may be looking at DNS 4.0, though frankly I expect that most users stick to the high-level API, which has not changed.  Only folks playing directly with `DNSMessage`, `lookupRaw`, ... might notice some changes.

More remains to be done.  There should, for example, probably be a cache to remember which the nameserver (protocol + address) don't support EDNS, so that subsequent queries with the same resolver handle can avoid doing constant non-EDNS fallback.

The server side of the API (being a DNS server rather than client) is presently fairly anaemic. Not sure anyone really uses that, but more could perhaps be done to support replies in the context of a particular request, ensuring consistent handling of EDNS  between request and reply.  That said I have no present  need for DNS server support code in Haskell, and don't know whether anyone else does.