### PR TITLE
add AXFR types and error cases

### DIFF
--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -233,6 +233,12 @@ isTypeOf t ResourceRecord{..} = rrtype == t
 --             additional = []})
 --  @
 --
+--  AXFR requests cannot be performed with this interface.
+--
+--   >>> rs <- makeResolvSeed defaultResolvConf
+--   >>> withResolver rs $ \resolver -> lookupRaw resolver "mew.org" AXFR
+--   Left NonZoneTransferAXFRRequest
+--
 lookupRaw :: Resolver   -- ^ Resolver obtained via 'withResolver'
           -> Domain     -- ^ Query domain
           -> TYPE       -- ^ Query RRtype

--- a/Network/DNS/LookupRaw.hs
+++ b/Network/DNS/LookupRaw.hs
@@ -237,7 +237,7 @@ isTypeOf t ResourceRecord{..} = rrtype == t
 --
 --   >>> rs <- makeResolvSeed defaultResolvConf
 --   >>> withResolver rs $ \resolver -> lookupRaw resolver "mew.org" AXFR
---   Left NonZoneTransferAXFRRequest
+--   Left InvalidAXFRLookup
 --
 lookupRaw :: Resolver   -- ^ Resolver obtained via 'withResolver'
           -> Domain     -- ^ Query domain

--- a/Network/DNS/Transport.hs
+++ b/Network/DNS/Transport.hs
@@ -75,7 +75,7 @@ type UdpRslv = Int -- Retry
 resolve :: Domain -> TYPE -> Resolver -> Rslv0
 resolve dom typ rlv qctls rcv
   | isIllegal dom = return $ Left IllegalDomain
-  | typ == AXFR   = return $ Left NonZoneTransferAXFRRequest
+  | typ == AXFR   = return $ Left InvalidAXFRLookup
   | onlyOne       = resolveOne        (head nss) (head gens) q tm retry ctls rcv
   | concurrent    = resolveConcurrent nss        gens        q tm retry ctls rcv
   | otherwise     = resolveSequential nss        gens        q tm retry ctls rcv

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -389,7 +389,7 @@ data DNSError =
     -- | A zone tranfer, i.e., a request of type AXFR, was attempted with the
     -- "lookup" interface. Zone transfer is different enough from "normal"
     -- requests that it requires a different interface.
-  | NonZoneTransferAXFRRequest
+  | InvalidAXFRLookup
     -- | The number of retries for the request was exceeded.
   | RetryLimitExceeded
     -- | TCP fallback request timed out.

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -42,6 +42,7 @@ module Network.DNS.Types (
   , CDS
   , CDNSKEY
   , CSYNC
+  , AXFR
   , ANY
   , CAA
   )
@@ -244,12 +245,15 @@ pattern CDNSKEY    = TYPE  60 -- RFC 7344
 -- | Child-To-Parent Synchronization (RFC7477)
 pattern CSYNC :: TYPE
 pattern CSYNC      = TYPE  62 -- RFC 7477
+-- | Zone transfer (RFC5936)
+pattern AXFR :: TYPE
+pattern AXFR       = TYPE 252 -- RFC 5936
 -- | A request for all records the server/cache has available
 pattern ANY :: TYPE
 pattern ANY        = TYPE 255
--- | A request for all records the server/cache has available
+-- | Certification Authority Authorization (RFC6844)
 pattern CAA :: TYPE
-pattern CAA        = TYPE 257
+pattern CAA        = TYPE 257 -- RFC 6844
 
 -- | From number to type.
 toTYPE :: Word16 -> TYPE
@@ -278,9 +282,10 @@ data TYPE = A          -- ^ IPv4 address
           | CDS        -- ^ Child DS (RFC7344)
           | CDNSKEY    -- ^ DNSKEY(s) the Child wants reflected in DS (RFC7344)
           | CSYNC      -- ^ Child-To-Parent Synchronization (RFC7477)
+          | AXFR       -- ^ Zone transfer (RFC5936)
           | ANY        -- ^ A request for all records the server/cache
                        --   has available
-          | CAA        -- ^ Certification Authority Authorization
+          | CAA        -- ^ Certification Authority Authorization (RFC6844)
           | UnknownTYPE Word16  -- ^ Unknown type
           deriving (Eq, Ord, Read)
 
@@ -308,6 +313,7 @@ fromTYPE TLSA       = 52
 fromTYPE CDS        = 59
 fromTYPE CDNSKEY    = 60
 fromTYPE CSYNC      = 62
+fromTYPE AXFR       = 252
 fromTYPE ANY        = 255
 fromTYPE CAA        = 257
 fromTYPE (UnknownTYPE x) = x
@@ -336,6 +342,7 @@ toTYPE 52 = TLSA
 toTYPE 59 = CDS
 toTYPE 60 = CDNSKEY
 toTYPE 62 = CSYNC
+toTYPE 252 = AXFR
 toTYPE 255 = ANY
 toTYPE 257 = CAA
 toTYPE x   = UnknownTYPE x
@@ -364,6 +371,7 @@ instance Show TYPE where
     show CDS        = "CDS"
     show CDNSKEY    = "CDNSKEY"
     show CSYNC      = "CSYNC"
+    show AXFR       = "AXFR"
     show ANY        = "ANY"
     show CAA        = "CAA"
     show x          = "TYPE" ++ show (fromTYPE x)
@@ -375,6 +383,13 @@ data DNSError =
     -- | The sequence number of the answer doesn't match our query. This
     --   could indicate foul play.
     SequenceNumberMismatch
+    -- | The question section of the response doesn't match our query. This
+    --   could indicate foul play.
+  | QuestionMismatch
+    -- | A zone tranfer, i.e., a request of type AXFR, was attempted with the
+    -- "lookup" interface. Zone transfer is different enough from "normal"
+    -- requests that it requires a different interface.
+  | NonZoneTransferAXFRRequest
     -- | The number of retries for the request was exceeded.
   | RetryLimitExceeded
     -- | TCP fallback request timed out.


### PR DESCRIPTION
@vdukhovni I have implemented some of your suggested changes from #134 in this new PR:

- documented CAA, including mention of the RFC
- added AXFR types
- added an error constructor to prevent sending an AXFR request from the existing interface
- added an error constructor to differentiate between sequence number and question mismatch
- made the question validation optional in the new `checkRespM`, for future zone transfer use