### PR TITLE
Add rrlength to ResourceRecord.

### DIFF
--- a/Network/DNS/Decode/Parsers.hs
+++ b/Network/DNS/Decode/Parsers.hs
@@ -59,7 +59,7 @@ getResponse = do
         -- | Extract EDNS information from an OPT RR.
         --
         optEDNS :: ResourceRecord -> Maybe (EDNS, Word16)
-        optEDNS (ResourceRecord "." OPT udpsiz ttl' (RD_OPT opts)) =
+        optEDNS (ResourceRecord "." OPT udpsiz ttl' _ (RD_OPT opts)) =
             let hrc      = fromIntegral rc .&. 0x0f
                 erc      = shiftR (ttl' .&. 0xff000000) 20 .|. hrc
                 secok    = ttl' `testBit` 15
@@ -133,7 +133,7 @@ getResourceRecord = do
     ttl <- get32
     len <- getInt16
     dat <- fitSGet len $ getRData typ len
-    return $ ResourceRecord dom typ cls ttl dat
+    return $ ResourceRecord dom typ cls ttl (fromIntegral len) dat
 
 ----------------------------------------------------------------
 

--- a/Network/DNS/Encode/Builders.hs
+++ b/Network/DNS/Encode/Builders.hs
@@ -12,6 +12,7 @@ module Network.DNS.Encode.Builders (
   , putDomain
   , putMailbox
   , putResourceRecord
+  , putRData
   ) where
 
 import Control.Monad.State (State, modify, execState, gets)
@@ -57,8 +58,9 @@ putDNSMessage msg = putHeader hd
       where
         prependOpt ads = mapEDNS eh (fromEDNS ads $ fromRCODE rc) ads
           where
+            -- rrlength goes unused during encoding; hence we just use 0 here:
             fromEDNS :: AdditionalRecords -> Word16 -> EDNS -> AdditionalRecords
-            fromEDNS rrs rc' edns = ResourceRecord name' type' class' ttl' rdata' : rrs
+            fromEDNS rrs rc' edns = ResourceRecord name' type' class' ttl' 0 rdata' : rrs
               where
                 name'  = BS.singleton '.'
                 type'  = OPT

--- a/Network/DNS/Encode/Builders.hs
+++ b/Network/DNS/Encode/Builders.hs
@@ -12,7 +12,6 @@ module Network.DNS.Encode.Builders (
   , putDomain
   , putMailbox
   , putResourceRecord
-  , putRData
   ) where
 
 import Control.Monad.State (State, modify, execState, gets)

--- a/Network/DNS/Encode/Builders.hs
+++ b/Network/DNS/Encode/Builders.hs
@@ -57,7 +57,7 @@ putDNSMessage msg = putHeader hd
       where
         prependOpt ads = mapEDNS eh (fromEDNS ads $ fromRCODE rc) ads
           where
-            -- rrlength goes unused during encoding; hence we just use 0 here:
+            -- rrlength is not used to encode; hence we just use 0 here:
             fromEDNS :: AdditionalRecords -> Word16 -> EDNS -> AdditionalRecords
             fromEDNS rrs rc' edns = ResourceRecord name' type' class' ttl' 0 rdata' : rrs
               where

--- a/Network/DNS/IO.hs
+++ b/Network/DNS/IO.hs
@@ -156,23 +156,23 @@ encodeVC legacyQuery =
 -- be added to the response message, or else a 'FormatErr' response
 -- must be sent.  The response TTL defaults to 300 seconds, and
 -- should be updated (to the same value across all the RRs) if some
--- other TTL value is more appropriate.
+-- other TTL value is more appropriate.  The 'rrlength' fields equal 4.
 --
 responseA :: Identifier -> Question -> [IPv4] -> DNSMessage
 responseA idt q ips = makeResponse idt q as
   where
     dom = qname q
-    as  = ResourceRecord dom A classIN 300 . RD_A <$> ips
+    as  = ResourceRecord dom A classIN 300 4 . RD_A <$> ips
 
 -- | Compose a response with a single IPv6 RRset.  If the query
 -- had an EDNS pseudo-header, a suitable EDNS pseudo-header must
 -- be added to the response message, or else a 'FormatErr' response
 -- must be sent.  The response TTL defaults to 300 seconds, and
 -- should be updated (to the same value across all the RRs) if some
--- other TTL value is more appropriate.
+-- other TTL value is more appropriate.  The 'rrlength' fields equal 16.
 --
 responseAAAA :: Identifier -> Question -> [IPv6] -> DNSMessage
 responseAAAA idt q ips = makeResponse idt q as
   where
     dom = qname q
-    as  = ResourceRecord dom AAAA classIN 300 . RD_AAAA <$> ips
+    as  = ResourceRecord dom AAAA classIN 300 16 . RD_AAAA <$> ips

--- a/Network/DNS/Types.hs
+++ b/Network/DNS/Types.hs
@@ -1222,11 +1222,14 @@ type TTL = Word32
 
 -- | Raw data format for resource records.
 data ResourceRecord = ResourceRecord {
-    rrname  :: !Domain -- ^ Name
-  , rrtype  :: !TYPE   -- ^ Resource record type
-  , rrclass :: !CLASS  -- ^ Resource record class
-  , rrttl   :: !TTL    -- ^ Time to live
-  , rdata   :: !RData  -- ^ Resource data
+    rrname   :: !Domain -- ^ Name
+  , rrtype   :: !TYPE   -- ^ Resource record type
+  , rrclass  :: !CLASS  -- ^ Resource record class
+  , rrttl    :: !TTL    -- ^ Time to live
+  , rrlength :: !Word16 -- ^ Encoded length of 'rdata' (as specified
+                        -- in the resource record header, even if only
+                        -- a prefix was decoded; ignored while encoding)
+  , rdata    :: !RData  -- ^ Resource data
   } deriving (Eq,Show)
 
 ----------------------------------------------------------------

--- a/dns.cabal
+++ b/dns.cabal
@@ -88,7 +88,8 @@ Test-Suite spec
   Hs-Source-Dirs:       test
   Ghc-Options:          -Wall
   Main-Is:              Spec.hs
-  Other-Modules:        EncodeSpec
+  Other-Modules:        CollapseLength
+                        EncodeSpec
                         DecodeSpec
                         RoundTripSpec
   Build-Depends:        dns

--- a/test/CollapseLength.hs
+++ b/test/CollapseLength.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module CollapseLength where
+
+import Data.Function (on)
+import Network.DNS
+import Test.Hspec (Expectation, shouldBe)
+
+class CollapseLength a where
+  -- | Sets 'rrlength' fields to 0.
+  collapseLength :: a -> a
+
+instance CollapseLength b => CollapseLength (Either a b) where
+  collapseLength = fmap collapseLength
+
+instance CollapseLength DNSMessage where
+  collapseLength DNSMessage{..} = DNSMessage
+    { answer = map collapseLength answer
+    , authority = map collapseLength authority
+    , additional = map collapseLength additional
+    , .. }
+
+instance CollapseLength ResourceRecord where
+  collapseLength ResourceRecord{..} = ResourceRecord
+    { rrlength = 0
+    , .. }
+
+-- | Applies 'collapseLength' before comparison,
+-- which is useful in tests that compare a synthesized
+-- DNS message or resource record with a decoded one.
+--
+-- Of course, do not collapse the length if your test
+-- is intended to check whether the length field in an
+-- encoded resource record header has a particular value.
+shouldBeCL :: (CollapseLength a, Eq a, Show a) => a -> a -> Expectation
+shouldBeCL = shouldBe `on` collapseLength
+infix 1 `shouldBeCL`

--- a/test/EncodeSpec.hs
+++ b/test/EncodeSpec.hs
@@ -2,6 +2,7 @@
 
 module EncodeSpec where
 
+import CollapseLength (shouldBeCL)
 import Data.IP
 import Network.DNS
 import Network.DNS.Types (defaultQuery, Question(..))
@@ -24,7 +25,7 @@ spec = do
             check2 testResponseTXT
 
 check1 :: DNSMessage -> Expectation
-check1 inp = out `shouldBe` Right inp
+check1 inp = out `shouldBeCL` Right inp
   where
     bs = encode inp
     out = decode bs
@@ -78,24 +79,24 @@ testResponseA = DNSMessage {
                    }
                 ]
   , answer =
-        [ ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [119, 147, 15, 122])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [119, 147, 79, 106])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [183, 60, 55, 43])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [183, 60, 55, 107])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [113, 108, 7, 172])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [113, 108, 7, 174])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [113, 108, 7, 175])
-        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 (RD_A $ toIPv4 [119, 147, 15, 100])
+        [ ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [119, 147, 15, 122])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [119, 147, 79, 106])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [183, 60, 55, 43])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [183, 60, 55, 107])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [113, 108, 7, 172])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [113, 108, 7, 174])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [113, 108, 7, 175])
+        , ResourceRecord "492056364.qzone.qq.com." A classIN 568 0 (RD_A $ toIPv4 [119, 147, 15, 100])
         ]
   , authority =
-        [ ResourceRecord "qzone.qq.com." NS classIN 45919 (RD_NS "ns-tel2.qq.com.")
-        , ResourceRecord "qzone.qq.com." NS classIN 45919 (RD_NS "ns-tel1.qq.com.")
+        [ ResourceRecord "qzone.qq.com." NS classIN 45919 0 (RD_NS "ns-tel2.qq.com.")
+        , ResourceRecord "qzone.qq.com." NS classIN 45919 0 (RD_NS "ns-tel1.qq.com.")
         ]
   , additional =
-        [ ResourceRecord "ns-tel1.qq.com." A classIN 46520 (RD_A $ toIPv4 [121, 14, 73, 115])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [222, 73, 76, 226])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [183, 60, 3, 202])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [218, 30, 72, 180])
+        [ ResourceRecord "ns-tel1.qq.com." A classIN 46520 0 (RD_A $ toIPv4 [121, 14, 73, 115])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [222, 73, 76, 226])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [183, 60, 3, 202])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [218, 30, 72, 180])
         ]
   }
 
@@ -122,16 +123,16 @@ testResponseTXT = DNSMessage {
                    }
                 ]
   , answer =
-        [ ResourceRecord "492056364.qzone.qq.com." TXT classIN 0 (RD_TXT "simple txt line")
+        [ ResourceRecord "492056364.qzone.qq.com." TXT classIN 0 0 (RD_TXT "simple txt line")
         ]
   , authority =
-        [ ResourceRecord "qzone.qq.com." NS classIN 45919 (RD_NS "ns-tel2.qq.com.")
-        , ResourceRecord "qzone.qq.com." NS classIN 45919 (RD_NS "ns-tel1.qq.com.")
+        [ ResourceRecord "qzone.qq.com." NS classIN 45919 0 (RD_NS "ns-tel2.qq.com.")
+        , ResourceRecord "qzone.qq.com." NS classIN 45919 0 (RD_NS "ns-tel1.qq.com.")
         ]
   , additional =
-        [ ResourceRecord "ns-tel1.qq.com." A classIN 46520 (RD_A $ toIPv4 [121, 14, 73, 115])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [222, 73, 76, 226])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [183, 60, 3, 202])
-        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 (RD_A $ toIPv4 [218, 30, 72, 180])
+        [ ResourceRecord "ns-tel1.qq.com." A classIN 46520 0 (RD_A $ toIPv4 [121, 14, 73, 115])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [222, 73, 76, 226])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [183, 60, 3, 202])
+        , ResourceRecord "ns-tel2.qq.com." A classIN 2890 0 (RD_A $ toIPv4 [218, 30, 72, 180])
         ]
   }

--- a/test/RoundTripSpec.hs
+++ b/test/RoundTripSpec.hs
@@ -2,6 +2,7 @@
 
 module RoundTripSpec where
 
+import CollapseLength (shouldBeCL)
 import Control.Monad (replicateM)
 import qualified Data.IP
 import Data.IP (Addr, IP(..), IPv4, IPv6, toIPv4, toIPv6, makeAddrRange)
@@ -56,14 +57,14 @@ spec = do
 
     prop "ResourceRecord" . forAll genResourceRecord $ \ rr -> do
         let bs = encodeResourceRecord rr
-        decodeResourceRecord bs `shouldBe` Right rr
+        decodeResourceRecord bs `shouldBeCL` Right rr
         fmap encodeResourceRecord (decodeResourceRecord bs) `shouldBe` Right bs
 
     prop "DNSHeader" . forAll (genDNSHeader 0x0f) $ \ hdr ->
         decodeDNSHeader (encodeDNSHeader hdr) `shouldBe` Right hdr
 
     prop "DNSMessage" . forAll genDNSMessage $ \ msg ->
-        decode (encode msg) `shouldBe` Right msg
+        decode (encode msg) `shouldBeCL` Right msg
 
     prop "EDNS" . forAll genEDNSHeader $ \(edns, hdr) -> do
         let eh = EDNSheader edns
@@ -105,7 +106,7 @@ genResourceRecord = frequency
       dom <- genDomain
       t <- elements [A, AAAA, NS, TXT, MX, CNAME, SOA, PTR, SRV, DNAME, DS,
                      TLSA, NSEC, NSEC3]
-      ResourceRecord dom t classIN <$> genWord32 <*> mkRData dom t
+      ResourceRecord dom t classIN <$> genWord32 <*> pure 0 <*> mkRData dom t
 
 mkRData :: Domain -> TYPE -> Gen RData
 mkRData dom typ =


### PR DESCRIPTION
This field may help identify inefficient or malicious encodings.

When decoding, rrlength tracks the length of the payload of
the resource record as specified in the resource record header,
regardless of whether that length is the minimum necessary.

Encoding ignores rrlength; when you construct a ResourceRecord
for the purpose of encoding it, you may set rrlength to any value.