### PR TITLE
POC of streaming AXFR with Conduit wrapper

### DIFF
--- a/Network/DNS/Transport.hs
+++ b/Network/DNS/Transport.hs
@@ -4,6 +4,7 @@
 module Network.DNS.Transport (
     Resolver(..)
   , resolve
+  , tcpOpen
   ) where
 
 import Control.Concurrent.Async (async, waitAnyCancel)

--- a/Network/DNS/ZoneTransfer.hs
+++ b/Network/DNS/ZoneTransfer.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.DNS.ZoneTransfer (
+    RRStream
+  , initiateZoneTransfer
+  , nextRecord
+  , closeRRStream
+  ) where
+
+import qualified Data.ByteString.Char8 as BS
+import           Data.IORef            (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.List.NonEmpty    as NE
+import           Data.Maybe            (fromMaybe)
+import           Network.Socket        (AddrInfo, Socket, addrAddress, close,
+                                        connect)
+
+import Network.DNS.IO
+import Network.DNS.Transport
+import Network.DNS.Types
+import Network.DNS.Types.Internal
+
+data RRStream = RRStream
+  { socket    :: Socket
+  , timeout   :: Int
+  , responses :: IORef AXFRResponses
+  }
+
+data AXFRResponses = AXFRResponses
+  { receivedLast :: Bool
+  , rrsInLatest  :: [ResourceRecord]
+  }
+
+initiateZoneTransfer :: Resolver -> Domain -> IO RRStream
+initiateZoneTransfer rlv zone = do
+  -- FIXME check for illegal domain
+  let gen = NE.head $ genIds rlv
+      seed = resolvseed rlv
+      nss = NE.head $ nameservers seed
+      conf = resolvconf seed
+      ctls = resolvQueryControls conf
+      tm = resolvTimeout conf
+
+  ref <- newIORef $ AXFRResponses False []
+  -- FIXME wrap with timeout
+  -- FIXME check the first message is SOA
+  vc <- axfrConnect gen nss zone ctls
+  let rrst = RRStream vc tm ref
+  receiveOneMessage rrst
+  return rrst
+
+nextRecord :: RRStream -> IO (Maybe ResourceRecord)
+nextRecord rrst = do
+  resps <- readIORef $ responses rrst
+  case rrsInLatest resps of
+    (x:xs) -> do
+      let new = AXFRResponses (receivedLast resps) xs
+      writeIORef (responses rrst) new
+      return (Just x)
+    [] -> do
+      if receivedLast resps
+      then return Nothing
+      else do
+        receiveOneMessage rrst
+        nextRecord rrst
+
+closeRRStream :: RRStream -> IO ()
+closeRRStream = close . socket
+
+receiveOneMessage :: RRStream -> IO ()
+receiveOneMessage rrst = do
+  -- FIXME wrap timeout
+  msg <- receiveVC $ socket rrst
+  let isLast = (rrtype . last . answer) msg == SOA
+      new = AXFRResponses (isLast) (answer msg)
+  writeIORef (responses rrst) new
+
+axfrConnect :: IO Identifier -> AddrInfo -> Domain -> QueryControls -> IO Socket
+axfrConnect gen ai zone ctls = do
+  let addr = addrAddress ai
+  sock <- tcpOpen addr
+  ident <- gen
+  let dottedZone = fromMaybe zone (BS.stripSuffix "." zone) <> "."
+      q = Question dottedZone AXFR
+      qry = encodeQuestion ident q ctls
+  connect sock addr
+  sendVC sock qry
+  return sock

--- a/Network/DNS/ZoneTransfer/Conduit.hs
+++ b/Network/DNS/ZoneTransfer/Conduit.hs
@@ -1,0 +1,12 @@
+module Network.DNS.ZoneTransfer.Conduit where
+
+import Conduit (ConduitT, MonadResource, bracketP, liftIO, yield)
+
+import Network.DNS.Types
+import Network.DNS.Types.Internal
+import Network.DNS.ZoneTransfer
+
+zoneTransferC :: MonadResource m
+              => Resolver -> Domain -> ConduitT () ResourceRecord m ()
+zoneTransferC rlv zone = bracketP (initiateZoneTransfer rlv zone) closeRRStream handle
+  where handle rrst = liftIO (nextRecord rrst) >>= maybe (return ()) (\rr -> yield rr >> handle rrst)

--- a/dns.cabal
+++ b/dns.cabal
@@ -22,6 +22,14 @@ Tested-With:            GHC == 7.10.3
 Custom-Setup
   Setup-Depends:        base, Cabal, cabal-doctest >=1.0.6 && <1.1
 
+Executable test-case
+  Hs-Source-Dirs:       test3
+  Ghc-Options:          -Wall
+  Main-Is:              Main.hs
+  Build-Depends:        base
+                      , conduit
+                      , dns
+
 Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
@@ -36,6 +44,8 @@ Library
                         Network.DNS.Encode
                         Network.DNS.Encode.Internal
                         Network.DNS.IO
+                        Network.DNS.ZoneTransfer
+                        Network.DNS.ZoneTransfer.Conduit
   Other-Modules:        Network.DNS.Base32Hex
                         Network.DNS.Decode.Parsers
                         Network.DNS.Encode.Builders
@@ -55,6 +65,7 @@ Library
                       , base64-bytestring
                       , binary
                       , bytestring
+                      , conduit
                       , containers
                       , cryptonite
                       , hourglass

--- a/test3/Main.hs
+++ b/test3/Main.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Conduit
+import Network.DNS
+import Network.DNS.ZoneTransfer.Conduit
+
+main :: IO ()
+main = do
+  rs <- makeResolvSeed defaultResolvConf { resolvInfo = RCHostName "81.4.108.41" }
+  withResolver rs $ \resolver -> (runConduitRes $ zoneTransferC resolver "zonetransfer.me" .| sinkList) >>= print . length


### PR DESCRIPTION
Follow up from https://github.com/kazu-yamamoto/dns/pull/134. This is a POC only to determine if the approach matches @vdukhovni's expectations.

Notes:

* I have added a Conduit module using the interface and an executable using that interface for demonstration purposes only. It will not be in the final PR.
* As I was working on it, I found it easier to use exceptions rather than weave Either DNSError around (it also follows the advice from https://www.fpcomplete.com/blog/2016/11/exceptions-best-practices-haskell to not use EitherT error around IO). What is the rationale for having Eithers? Do we want Eithers for the streaming? If so, I'll work on the change.
