### PR TITLE
Cabal and CI update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.0.2"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   global:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
   matrix:
-    - GHCVER: "8.6.4"
+    - GHCVER: "8.6.5"
 
 platform:
 #  - x86 # We may want to test x86 as well, but it would double the 23min build time.
@@ -23,7 +23,6 @@ install:
  - "ghc --version"
  - "cabal %CABOPTS% update -vverbose+nowrap"
  - "cabal %CABOPTS% install hspec-discover"
- - "cabal %CABOPTS% install cabal-doctest"
 
 build: off
 deploy: off
@@ -32,5 +31,8 @@ test_script:
  - cabal %CABOPTS% new-build -j1 -vnormal+nowrap --dry all
  - ps: Push-AppveyorArtifact dist-newstyle\cache\plan.json
  - cabal %CABOPTS% new-build -j1 -vnormal+nowrap all
- - cabal %CABOPTS% new-test  -j1 -vnormal+nowrap all
+ # On Windows, doctests don't yet work due to missing cbits
+ # dependency, so we run just the 'network' and 'spec' tests.
+ - cabal %CABOPTS% new-test  -j1 -vnormal+nowrap network
+ - cabal %CABOPTS% new-test  -j1 -vnormal+nowrap spec
  - ps: ls dns*.log -recurse | %{ Push-AppveyorArtifact $_}

--- a/dns.cabal
+++ b/dns.cabal
@@ -9,13 +9,11 @@ Description:
   A thread-safe DNS library for both clients and servers written
   in pure Haskell.
 Category:               Network
-Cabal-Version:          >= 1.10
+Cabal-Version:          >= 2.0
 Build-Type:             Custom
 Extra-Source-Files:     Changelog.md
                         cbits/dns.c
-Tested-With:            GHC == 7.10.3
-                      , GHC == 8.0.2
-                      , GHC == 8.2.2
+Tested-With:            GHC == 8.2.2
                       , GHC == 8.4.4
                       , GHC == 8.6.5
 
@@ -93,9 +91,13 @@ Test-Suite spec
                       , base
                       , bytestring
                       , hspec
-                      , iproute >= 1.2.4
+                      , iproute >= 1.3.2
                       , word8
 
+-- The doctests don't presently work on Windows, due to an unresolved
+-- cbits/dns.c dependency.  Documentation on how to link custom C-code
+-- via cabal-doctest is not provided.
+--
 Test-Suite doctests
   Type:                 exitcode-stdio-1.0
   Default-Language:     Haskell2010


### PR DESCRIPTION
- Require Cabal >= 2.0
- Drop GHC 8.0 support
- Test GHC 8.6.5 also on Windows
- Disable non-working doctests on Windows for now, don't know how
  to link cbits/dns.c into the doctests executable.