### PR TITLE
Introduce a flag to avoid service resolution

### DIFF
--- a/Network/DNS/Resolver.hs
+++ b/Network/DNS/Resolver.hs
@@ -67,12 +67,12 @@ makeResolvSeed conf = ResolvSeed conf <$> findAddresses
 
 makeAddrInfo :: HostName -> Maybe PortNumber -> IO AddrInfo
 makeAddrInfo addr mport = do
-    let flgs = [AI_ADDRCONFIG, AI_NUMERICHOST, AI_PASSIVE]
-        hints = defaultHints {
-            addrFlags = if isJust mport then AI_NUMERICSERV : flgs else flgs
+    let hints = defaultHints {
+            addrFlags = [AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV, AI_PASSIVE]
           , addrSocketType = Datagram
           }
-        serv = maybe "domain" show mport
+        -- 53 is the standard port number for domain name servers as assigned by IANA
+        serv = maybe "53" show mport
     head <$> getAddrInfo (Just hints) (Just addr) (Just serv)
 
 ----------------------------------------------------------------


### PR DESCRIPTION
Hi Kazu,

Haskell applications distributed as a statically linked executable typically use musl libc. This library hardcodes the `services` file location to `/etc/services` while some Linux distributions have started using GNU libc machinery (`/etc/nsswitch.conf`) to migrate `services` to `/usr/etc/services`.

While acknowledging that this is not because of a bug in the `dns` library,  using the `dns` library in the situation above would fail. 

Indeed, when resolving the address of the dns server we want to use we call `getAddrInfo` with the serivce name `domain`. This triggers a service resolution procedure provided by libc, which hits the different expectations between musl libc and gnu libc.

For consumers who need to fix this behaviour, it is useful to have a compile time flag that avoid this service resolution entirely and instead hardcodes the standard port 53 for DNS queries.

An example of this is cardano-node, which doesn't work at all on openSUSE, failing to contact the DNS server.:
```
[fino:cardano.node.DnsResolver:Error:233] [2022-06-15 06:08:50.66 UTC] Domain: "relays-new.cardano-mainnet.iohk.io" lookup exception Network.Socket.getAddrInfo (called with preferred socket type/protocol: AddrInfo {addrFlags = [AI_ADDRCONFIG,AI_NUMERICHOST,AI_PASSIVE], addrFamily = AF_UNSPEC, addrSocketType = Datagram, addrProtocol = 0, addrAddress = 0.0.0.0:0, addrCanonName = Nothing}, host name: Just "10.43.10.1", service name: Just "domain"): does not exist (Unrecognized service)
```

I hope you can consider this patch. I am keen to hear what you think.