### PR TITLE
Use showTXT to present the value of a CAA record.

### DIFF
--- a/internal/Network/DNS/Types/Internal.hs
+++ b/internal/Network/DNS/Types/Internal.hs
@@ -1080,7 +1080,7 @@ instance Show RData where
           show usage ++ " " ++ show selector ++ " " ++
           show mtype ++ " " ++ _b16encode digest
       showCAA flags tag value =
-          show flags ++ " " ++ BS.unpack (CI.original tag) ++ " " ++ show value
+          show flags ++ " " ++ BS.unpack (CI.original tag) ++ " " ++ showTXT value
       -- | Opaque RData: <https://tools.ietf.org/html/rfc3597#section-5>
       showOpaque bs = unwords ["\\#", show (BS.length bs), _b16encode bs]
 


### PR DESCRIPTION
The presentation form of the value for a CAA RR is the same as with DNS character strings (just not limited to 255 bytes).  Therefore, we need to use `showTXT` not `show` to present the value.